### PR TITLE
Fix IRC->Ingame Kicks, and make ingame kicks fire rawsend KICK instead of a QUIT

### DIFF
--- a/res/config.yml
+++ b/res/config.yml
@@ -28,6 +28,9 @@ debug-mode: no
 # With this enabled all server link traffic will be outputted to the console.
 enable-raw-send: no  
 # Lets you use the /rawsend command (console only) to send raw commands to the linked server. Don't enable this unless you know what you are doing.
+kick-commands:
+    - "kick"
+# Commands used to kick people
 standalone:
     port: 6667  # Port to use for the standalone IRC server.
     max-connections: 1000  # Max number of simultaneous connections.

--- a/src/com/Jdbye/BukkitIRCd/BukkitCommandExecutorRunnable.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitCommandExecutorRunnable.java
@@ -1,7 +1,7 @@
 package com.Jdbye.BukkitIRCd;
 
 import org.bukkit.scheduler.BukkitRunnable;
-
+import org.bukkit.event.server.ServerCommandEvent;
 public class BukkitCommandExecutorRunnable extends BukkitRunnable{
 
 	private String command;
@@ -12,8 +12,10 @@ public class BukkitCommandExecutorRunnable extends BukkitRunnable{
 	}
 
 	public void run() {
-		instance.getServer().dispatchCommand(instance.getServer().getConsoleSender(), command);
-		
+		//Call a ServerCommandEvent whenever a command is run from IRC to allow other plugins to get to it
+		ServerCommandEvent commandEvent = new ServerCommandEvent(instance.getServer().getConsoleSender(),command);
+		instance.getServer().getPluginManager().callEvent(commandEvent);
+		instance.getServer().dispatchCommand(commandEvent.getSender(), commandEvent.getCommand());
 	}
 	
 

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -7,7 +7,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.ServerCommandEvent;
@@ -23,21 +22,43 @@ public class BukkitIRCdPlayerListener implements Listener {
 		plugin = instance;
 	}
 
+	
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onServerCommand(ServerCommandEvent event){
+		
+		//Console Command Listener
+		String[] split = event.getCommand().split(" ");
+			
+		if (split.length > 1){
+			
+			if (BukkitIRCdPlugin.kickCommands.contains(split[0].toLowerCase())){
+			
+				//PlayerKickEvent does not give kicker, so we listen to kick commands instead
+					StringBuilder s = new StringBuilder(300);
+					for(int i = 2; i < split.length;i++){
+						 s.append(split[i]).append(" ");
+					}
+					String kickMessage = s.toString();
+					String kickedPlayer = split[1];
+					plugin.removeLastReceivedBy(kickedPlayer);
+					IRCd.kickBukkitUser(kickMessage, IRCd.getBukkitUser(kickedPlayer));
+			}
+		}
+	}
 	@EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event)
     {
             String mode = "";
             Player player = event.getPlayer();
-            //if (plugin.hasPermission(player, "bukkitircd.mode.owner")) mode += "~";
-            //if (plugin.hasPermission(player, "bukkitircd.mode.protect")) mode += "&";
+            if (plugin.hasPermission(player, "bukkitircd.mode.owner")) mode += "~";
+            if (plugin.hasPermission(player, "bukkitircd.mode.protect")) mode += "&";
+            //Most IRC networks have support for owner and superop mode. 
+            
+            
             if (plugin.hasPermission(player, "bukkitircd.mode.op")) mode += "@";
             if (plugin.hasPermission(player, "bukkitircd.mode.halfop")) mode += "%";
             if (plugin.hasPermission(player, "bukkitircd.mode.voice")) mode += "+";
-            //if (plugin.hasPermission("bukkitircd.mode.owner")) mode += "~";
-            //if (plugin.hasPermission("bukkitircd.mode.protect")) mode += "&";
-            //if (plugin.hasPermission("bukkitircd.mode.op")) mode += "@";
-            //if (plugin.hasPermission("bukkitircd.mode.halfop")) mode += "%";
-            //if (plugin.hasPermission("bukkitircd.mode.voice")) mode += "+";
+
             IRCd.addBukkitUser(mode,player);
     }
 
@@ -48,16 +69,6 @@ public class BukkitIRCdPlayerListener implements Listener {
 		plugin.removeLastReceivedBy(name);
 		IRCd.removeBukkitUser(IRCd.getBukkitUser(name));
 	}
-	/*
-	@EventHandler(priority = EventPriority.MONITOR)
-	public void onPlayerKick(PlayerKickEvent event)
-	{
-		if (event.isCancelled()) return;
-		String name = event.getPlayer().getName();
-		plugin.removeLastReceivedBy(name);
-		IRCd.kickBukkitUser(event.getReason(), IRCd.getBukkitUser(event.getPlayer().getName()));
-	}
-	*/
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerChat(AsyncPlayerChatEvent event)
@@ -100,7 +111,7 @@ public class BukkitIRCdPlayerListener implements Listener {
 			}
 			
 			
-			if (BukkitIRCdPlugin.kickCommands.contains(split[0].substring(1))){
+			if (BukkitIRCdPlugin.kickCommands.contains(split[0].substring(1).toLowerCase())){
 				//PlayerKickEvent does not give kicker, so we listen to kick commands instead
 				if (event.getPlayer().hasPermission("bukkitircd.kick")){
 					StringBuilder s = new StringBuilder(300);
@@ -109,10 +120,9 @@ public class BukkitIRCdPlayerListener implements Listener {
 					}
 					String kickMessage = s.toString();
 					String kickedPlayer = split[1];
-					System.out.println(kickMessage);
-					System.out.println(kickedPlayer);
 					BukkitPlayer bp;
 					if ((bp = IRCd.getBukkitUserObject(event.getPlayer().getName())) != null) {
+						plugin.removeLastReceivedBy(kickedPlayer);
 						IRCd.kickBukkitUser(kickMessage, IRCd.getBukkitUser(kickedPlayer), IRCd.getBukkitUser(event.getPlayer().getName()));
 					}
 					

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.server.ServerCommandEvent;
 
 /**
  * Handle events for all Player related events
@@ -47,7 +48,7 @@ public class BukkitIRCdPlayerListener implements Listener {
 		plugin.removeLastReceivedBy(name);
 		IRCd.removeBukkitUser(IRCd.getBukkitUser(name));
 	}
-
+	/*
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerKick(PlayerKickEvent event)
 	{
@@ -56,6 +57,7 @@ public class BukkitIRCdPlayerListener implements Listener {
 		plugin.removeLastReceivedBy(name);
 		IRCd.kickBukkitUser(event.getReason(), IRCd.getBukkitUser(event.getPlayer().getName()));
 	}
+	*/
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerChat(AsyncPlayerChatEvent event)
@@ -74,6 +76,7 @@ public class BukkitIRCdPlayerListener implements Listener {
 		event.setMessage(IRCd.stripFormatting(event.getMessage()));
 	}
 
+	
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event)
 	{
@@ -95,8 +98,30 @@ public class BukkitIRCdPlayerListener implements Listener {
 				}
 				event.setMessage(IRCd.stripFormatting(event.getMessage()));
 			}
+			
+			
+			if (BukkitIRCdPlugin.kickCommands.contains(split[0].substring(1))){
+				//PlayerKickEvent does not give kicker, so we listen to kick commands instead
+				if (event.getPlayer().hasPermission("bukkitircd.kick")){
+					StringBuilder s = new StringBuilder(300);
+					for(int i = 2; i < split.length;i++){
+						 s.append(split[i]).append(" ");
+					}
+					String kickMessage = s.toString();
+					String kickedPlayer = split[1];
+					System.out.println(kickMessage);
+					System.out.println(kickedPlayer);
+					BukkitPlayer bp;
+					if ((bp = IRCd.getBukkitUserObject(event.getPlayer().getName())) != null) {
+						IRCd.kickBukkitUser(kickMessage, IRCd.getBukkitUser(kickedPlayer), IRCd.getBukkitUser(event.getPlayer().getName()));
+					}
+					
+					}
+				}
+				
+			}
 		}
-	}
+	
 	
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerMove(PlayerMoveEvent event)

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -10,6 +10,7 @@ import java.io.OutputStreamWriter;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -94,6 +95,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public static int link_delay = 60;
 	public static int link_serverid = new Random().nextInt(900) + 100;
 
+	public static List<String> kickCommands = Arrays.asList("/kick");
 	public static final Logger log = Logger.getLogger("Minecraft");
 	
 	private boolean enableRawSend = false;
@@ -334,6 +336,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			ircd_bantype = config.getString("ban-type", ircd_bantype);
 			debugmode = config.getBoolean("debug-mode", debugmode);
 			enableRawSend = config.getBoolean("enable-raw-send", enableRawSend);
+			kickCommands = config.getStringList("kick-commands");
 
 			String operpass = "";
 			ircd_port = config.getInt("standalone.port", ircd_port);

--- a/src/com/Jdbye/BukkitIRCd/BukkitKickRunnable.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitKickRunnable.java
@@ -1,0 +1,29 @@
+package com.Jdbye.BukkitIRCd;
+
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public class BukkitKickRunnable extends BukkitRunnable{
+
+
+	//We need this to avoid async kicks. 
+	//Kicks are not thread safe
+	private Player kickedPlayer;
+	private String kickReason;
+	private final BukkitIRCdPlugin instance;
+	
+	public BukkitKickRunnable(BukkitIRCdPlugin instance, Player kickedPlayer, String kickReason){
+		this.kickedPlayer = kickedPlayer;
+		this.kickReason = kickReason;
+		this.instance = instance;
+		
+	}
+
+	public void run() {
+		kickedPlayer.kickPlayer(kickReason);
+	}
+	
+	
+	
+	
+}

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -1265,7 +1265,6 @@ public class IRCd implements Runnable {
 					kickReason = " :"+convertColors(kickReason,false);
 				}
 				if (mode == Modes.STANDALONE) {
-					//TODO StandaloneKick
 					writeAll(":" + serverName + "!" + serverName + "@" + serverHostName + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + kickReason);
 				}
 				else {
@@ -2115,7 +2114,6 @@ public class IRCd implements Runnable {
 						BukkitPlayer bp;
 						if ((bp = getBukkitUserByUID(split[3])) != null) {
 							if ((IRCd.isPlugin) && (BukkitIRCdPlugin.thePlugin != null)) {
-								//TODO Remove Suffix
 								Player p = BukkitIRCdPlugin.thePlugin.getServer().getPlayer(bp.nick);
 								if (p != null) {
 									if (reason != null) p.kickPlayer("Kicked by " + user + " on IRC: " + reason);

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -1249,6 +1249,7 @@ public class IRCd implements Runnable {
 		return false;
 	}
 
+	/*
 	// This is where we need to modify the disconnect on kick to a proper kick instead
 	public static boolean kickBukkitUser(String kickReason, int ID) {
 		if (ID >= 0) {
@@ -1267,8 +1268,37 @@ public class IRCd implements Runnable {
 			}
 		}
 		else return false;
-	}
+	}*/
 
+	public static boolean kickBukkitUser(String kickReason, int kickedID, int kickerID) {
+		if (kickedID >= 0) {
+			synchronized(csBukkitPlayers) {
+				BukkitPlayer kickedBukkitPlayer = bukkitPlayers.get(kickedID);
+				String kickedHost = kickedBukkitPlayer.host;
+				String kickedName = kickedBukkitPlayer.nick;
+				
+				BukkitPlayer kickerBukkitPlayer = bukkitPlayers.get(kickerID);
+				String kickerHost = kickedBukkitPlayer.host;
+				String kickerName = kickerBukkitPlayer.nick;
+				
+				if (!kickReason.isEmpty()){
+					kickReason = " :"+convertColors(kickReason,false);
+				}
+				if (mode == Modes.STANDALONE) {
+					//TODO StandaloneKick
+					writeAll(":" + kickedName + ingameSuffix + "!" + kickedName + "@" + kickedHost + " QUIT :Kicked: " + convertColors(kickReason,false));
+				}
+				else {
+					
+					//KICK
+					println(":" + kickerBukkitPlayer.getUID() + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + kickReason);
+				}
+				bukkitPlayers.remove(kickedID);
+				return true;
+			}
+		}
+		else return false;
+	}
 	public static int getBukkitUser(String nick) {
 		synchronized(csBukkitPlayers) {
 			int i = 0;
@@ -2069,9 +2099,11 @@ public class IRCd implements Runnable {
 						BukkitPlayer bp;
 						if ((bp = getBukkitUserByUID(split[3])) != null) {
 							if ((IRCd.isPlugin) && (BukkitIRCdPlugin.thePlugin != null)) {
+								//TODO Remove Suffix
 								Player p = BukkitIRCdPlugin.thePlugin.getServer().getPlayer(bp.nick);
 								if (p != null) {
 									if (reason != null) p.kickPlayer("Kicked by " + user + " on IRC: " + reason);
+									//TODO Make this Synchronous
 									else p.kickPlayer("Kicked by " + user + " on IRC");
 								}
 								removeBukkitUserByUID(split[3]);
@@ -2704,10 +2736,12 @@ public class IRCd implements Runnable {
 									if (p != null) {
 										if (reason != null) {
 											if (IRCd.msgIRCKickReason.length() > 0) s.broadcastMessage(IRCd.msgIRCKickReason.replace("%KICKEDUSER%", bannick).replace("%KICKEDBY%", nick).replace("%REASON%", IRCd.convertColors(reason, true)));
+											//TODO Make this synchronous
 											p.kickPlayer("Kicked by " + nick + " on IRC: " + IRCd.stripFormatting(reason));
 										}
 										else {
 											if (IRCd.msgIRCKick.length() > 0) s.broadcastMessage(IRCd.msgIRCKick.replace("%KICKEDUSER%", bannick).replace("%KICKEDBY%", nick));
+											//TODO Make this synchronous
 											p.kickPlayer("Kicked by " + nick + " on IRC");
 										}
 									}

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -1249,33 +1249,50 @@ public class IRCd implements Runnable {
 		return false;
 	}
 
-	/*
+	
+	/**
+	 * Used for Console Kicks
+	 * @param kickReason
+	 * @param ID
+	 * @return
+	 */
 	// This is where we need to modify the disconnect on kick to a proper kick instead
-	public static boolean kickBukkitUser(String kickReason, int ID) {
-		if (ID >= 0) {
+	public static boolean kickBukkitUser(String kickReason, int kickedID) {
+		if (kickedID >= 0) {
 			synchronized(csBukkitPlayers) {
-				BukkitPlayer bukkitPlayer = bukkitPlayers.get(ID);
-				String host = bukkitPlayer.host;
-				String name = bukkitPlayer.nick;
+				BukkitPlayer kickedBukkitPlayer = bukkitPlayers.get(kickedID);
+				if (!kickReason.isEmpty()){
+					kickReason = " :"+convertColors(kickReason,false);
+				}
 				if (mode == Modes.STANDALONE) {
-					writeAll(":" + name + ingameSuffix + "!" + name + "@" + host + " QUIT :Kicked: " + convertColors(kickReason,false));
+					//TODO StandaloneKick
+					writeAll(":" + serverName + "!" + serverName + "@" + serverHostName + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + kickReason);
 				}
 				else {
-					println(":" + bukkitPlayer.getUID() + " QUIT :Kicked: " + convertColors(kickReason,false));
+					
+					//KICK
+					println(":" + serverUID + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + kickReason);
 				}
-				bukkitPlayers.remove(ID);
+				bukkitPlayers.remove(kickedID);
 				return true;
 			}
 		}
 		else return false;
-	}*/
+	}
+	
 
+	
+	/**
+	 * Used for player kicks
+	 * @param kickReason
+	 * @param kickedID
+	 * @param kickerID
+	 * @return
+	 */
 	public static boolean kickBukkitUser(String kickReason, int kickedID, int kickerID) {
 		if (kickedID >= 0) {
 			synchronized(csBukkitPlayers) {
 				BukkitPlayer kickedBukkitPlayer = bukkitPlayers.get(kickedID);
-				String kickedHost = kickedBukkitPlayer.host;
-				String kickedName = kickedBukkitPlayer.nick;
 				
 				BukkitPlayer kickerBukkitPlayer = bukkitPlayers.get(kickerID);
 				String kickerHost = kickedBukkitPlayer.host;
@@ -1285,13 +1302,12 @@ public class IRCd implements Runnable {
 					kickReason = " :"+convertColors(kickReason,false);
 				}
 				if (mode == Modes.STANDALONE) {
-					//TODO StandaloneKick
-					writeAll(":" + kickedName + ingameSuffix + "!" + kickedName + "@" + kickedHost + " QUIT :Kicked: " + convertColors(kickReason,false));
+					writeAll(":" + kickerName + ingameSuffix + "!" + kickerName + "@" + kickerHost + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + convertColors(kickReason,false));
 				}
 				else {
 					
 					//KICK
-					println(":" + kickerBukkitPlayer.getUID() + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + kickReason);
+					println(":" + kickerBukkitPlayer.getUID() + " KICK "+IRCd.channelName +" "+ kickedBukkitPlayer.nick + ingameSuffix + convertColors(kickReason,false));
 				}
 				bukkitPlayers.remove(kickedID);
 				return true;


### PR DESCRIPTION
Fixes Issue https://github.com/WMCAlliance/BukkitIRCd/issues/6

Tested both on standalone and InspIRCd link

Firstly, this makes all kicks from IRC (eg. `/kick ron975-mc #minecraft`) work again by making them synchronous (`kickPlayer()` is not thread safe).

Secondly, as mentioned before, this fixes https://github.com/WMCAlliance/BukkitIRCd/issues/6.
Instead of listening to `PlayerKickEvent`, it listens to Command Events such as `PlayerCommandPreprocessEvent` and `ServerCommandEvent`. 

Adding a configuration option, it listens for kick commands listed in config.yml. When it does, it checks for `bukkitircd.kick` (meaning that the kicker must have that permission when kicking someone if you wish for them to kick the linked IRC User as well. If a player is kicked without kicking their IRC User, it may cause exceptions). If the player does so, it fires a `KICK` IRC command, displaying something like `ron975-mc has kicked ron975-mc from #mystia (ron975-mc)` instead of the previous QUIT message.

Due to limitations in how the plugin handles nicknames, it won't work if the IRC nick doesn't match with the ingame name, it won't work. This might have happened before with the older code as well, I just haven't tested it. See issue https://github.com/WMCAlliance/BukkitIRCd/issues/25

Also, a small fix, makes IRC to ingame commands call a ServerComandEvent so Listeners can get to it (required for !kick [ingame name] in the staff channel to kick IRC user as well)
