### PR TITLE
Display messages in staff chan again, fixes issue 28

### DIFF
--- a/res/config.yml
+++ b/res/config.yml
@@ -31,6 +31,8 @@ enable-raw-send: no
 kick-commands:
     - "kick"
 # Commands used to kick people
+handle-ampersand-colors: true
+# Whether to handle color codes with the & prefix
 standalone:
     port: 6667  # Port to use for the standalone IRC server.
     max-connections: 1000  # Max number of simultaneous connections.

--- a/res/messages.yml
+++ b/res/messages.yml
@@ -29,4 +29,4 @@ irc-action-dynmap: "* %USER% %MESSAGE%"  # Displays on dynmap when someone sends
 irc-message-dynmap: "<%USER%> %MESSAGE%"  # Displays on dynmap when someone sends a message on IRC.
 irc-notice-dynmap: "-%USER%- %MESSAGE%"  # Displays on dynmap when someone sends a notice on IRC.
 dynmap-message: "[Map] %USER%: %MESSAGE%"  # Displays on IRC when someone sends a message on Dynmap.
-player-list: "^BWe have (%COUNT%) players online. They are:^B %USERS%"  # The template used for the !players IRC command. If you make this blank, the command will be disabled.
+player-list: "We have (&l%COUNT%&r) players online. They are: %USERS%"  # The template used for the !players IRC command. If you make this blank, the command will be disabled.

--- a/res/messages.yml
+++ b/res/messages.yml
@@ -17,7 +17,7 @@ irc-ban: "&3[IRC] &e%BANNEDUSER% was banned by %BANNEDBY%"  # Displays ingame wh
 irc-unban: "&3[IRC] &e%BANNEDUSER% was unbanned by %BANNEDBY%"  # Displays ingame when someone is unbanned from IRC.
 irc-ban-dynmap: "%BANNEDUSER% was banned by %BANNEDBY%"  # Displays on dynmap when someone is banned from IRC.
 irc-unban-dynmap: "%BANNEDUSER% was unbanned by %BANNEDBY%"  # Displays on dynmap when someone is unbanned from IRC.
-irc-nick-change: "&3[IRC] &e%OLDNICK% is now known as %NEWNICK%&f"  # Displays ingame when someone changes their nick on IRC.
+irc-nick-change: "&3[IRC] &e%OLDNICK% is now known as %NEWNICK%&r"  # Displays ingame when someone changes their nick on IRC.
 irc-nick-change-dynmap: "%OLDNICK% is now known as %NEWNICK%"  # Displays on dynmap when someone changes their nick on IRC.
 irc-action: "&r[IRC] * &7%USER%&r %MESSAGE%"  # Displays ingame when someone sends an action on IRC.
 irc-message: "&r[IRC] <&7%USER%&r> %MESSAGE%"  # Displays ingame when someone sends a message on IRC.

--- a/src/com/Jdbye/BukkitIRCd/BukkitCommandExecutorRunnable.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitCommandExecutorRunnable.java
@@ -1,19 +1,22 @@
 package com.Jdbye.BukkitIRCd;
 
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.command.CommandSender;
 import org.bukkit.event.server.ServerCommandEvent;
 public class BukkitCommandExecutorRunnable extends BukkitRunnable{
 
 	private String command;
 	private final BukkitIRCdPlugin instance;
-	public BukkitCommandExecutorRunnable(BukkitIRCdPlugin instance, String command){
+	private CommandSender sender;
+	public BukkitCommandExecutorRunnable(BukkitIRCdPlugin instance, String command, CommandSender sender){
 		this.command = command;
 		this.instance = instance;
+		this.sender = sender;
 	}
 
 	public void run() {
 		//Call a ServerCommandEvent whenever a command is run from IRC to allow other plugins to get to it
-		ServerCommandEvent commandEvent = new ServerCommandEvent(instance.getServer().getConsoleSender(),command);
+		ServerCommandEvent commandEvent = new ServerCommandEvent(sender,command);
 		instance.getServer().getPluginManager().callEvent(commandEvent);
 		instance.getServer().dispatchCommand(commandEvent.getSender(), commandEvent.getCommand());
 	}

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.logging.Logger;
-import java.util.regex.*;
-
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -74,6 +72,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public static long ircd_topicsetdate = System.currentTimeMillis() / 1000L;
 	public static String ircd_bantype = "ip";
 	private boolean ircd_convertcolorcodes = true;
+	private static boolean ircd_handleampersandcolors = true;
 	private static String ircd_version;
 	private static boolean ircd_enablenotices = true;
 	private String ircd_operuser = "";
@@ -238,6 +237,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		IRCd.ingameSuffix = ircd_ingamesuffix;
 		IRCd.enableNotices = ircd_enablenotices;
 		IRCd.convertColorCodes = ircd_convertcolorcodes;
+		IRCd.handleAmpersandColors = ircd_handleampersandcolors;
 		IRCd.ircBanType = ircd_bantype;
 		IRCd.version = ircd_version;
 		IRCd.operUser = ircd_operuser;
@@ -327,6 +327,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			ircd_ingamesuffix = config.getString("ingame-suffix", ircd_ingamesuffix);
 			ircd_enablenotices = config.getBoolean("enable-notices", ircd_enablenotices);
 			ircd_convertcolorcodes = config.getBoolean("convert-color-codes", ircd_convertcolorcodes);
+			ircd_handleampersandcolors = config.getBoolean("handle-ampersand-colors",ircd_handleampersandcolors);
 			ircd_irc_colors = config.getString("irc-colors", ircd_irc_colors);
 			ircd_game_colors = config.getString("game-colors", ircd_game_colors);
 			ircd_channel = config.getString("channel-name", ircd_channel);

--- a/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
@@ -24,12 +24,11 @@ public class IRCCommandSender implements CommandSender {
 
     public void sendMessage(String message) {
     	if (enabled) {
-    		if (!message.contains("IRC ")) { // Don't show IRC messages - this really needs to be improved
     			if (IRCd.mode == Modes.STANDALONE) IRCd.writeOpers(":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     			else if (IRCd.linkcompleted) IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     		}
     	}
-    }
+    
     
     public void sendMessage(String[] message) {
     	for (String s : message) sendMessage(s);
@@ -45,7 +44,7 @@ public class IRCCommandSender implements CommandSender {
 
     public boolean isOp() {
         //return client.isOper;
-    	return false;
+    	return true;
     }
 
     public void setOp(boolean value) {

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -98,6 +98,7 @@ public class IRCd implements Runnable {
 	public static long channelTopicSetDate = System.currentTimeMillis() / 1000L;
 	public static boolean enableNotices = true;
 	public static boolean convertColorCodes = true;
+	public static boolean handleAmpersandColors = true;
 	public String modestr = "standalone";
 	public static Modes mode;
 	
@@ -1592,7 +1593,11 @@ public class IRCd implements Runnable {
 			if (!convertColorCodes){
 				return ChatColor.stripColor(input);
 			}
+			if (handleAmpersandColors){
+			output = ChatColor.translateAlternateColorCodes('&', input);
+			}else{
 			output = input;
+			}
 			output = output.replace(MC_Color+"n",IRC_Under+"");
 			output = output.replace(MC_Color+"o",IRC_Ital+"");
 			output = output.replace(MC_Color+"l",IRC_Bold+"");

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -1703,7 +1703,7 @@ public class IRCd implements Runnable {
 	public static boolean executeCommand(String command) {
 		try {
 			if ((commandSender != null) && (bukkitServer != null)) {
-				BukkitTask commandTask = new BukkitCommandExecutorRunnable(BukkitIRCdPlugin.thePlugin,convertColors(command,true)).runTaskLater(BukkitIRCdPlugin.thePlugin,1L);
+				BukkitTask commandTask = new BukkitCommandExecutorRunnable(BukkitIRCdPlugin.thePlugin,convertColors(command,true),commandSender).runTaskLater(BukkitIRCdPlugin.thePlugin,1L);
 				return true;
 			}
 			else return false;


### PR DESCRIPTION
This fixes #28. Instead of using `ConsoleCommandSender`, I reverted back to using `IRCCommandSender` to send commands, however, it's now treated as op, and has all permission.

Also attempts to fix ampersands not parsing into colors.
