### PR TITLE
Make cancelling of IRC messages in staff channel more flexible

### DIFF
--- a/res/messages.yml
+++ b/res/messages.yml
@@ -30,3 +30,5 @@ irc-message-dynmap: "<%USER%> %MESSAGE%"  # Displays on dynmap when someone send
 irc-notice-dynmap: "-%USER%- %MESSAGE%"  # Displays on dynmap when someone sends a notice on IRC.
 dynmap-message: "[Map] %USER%: %MESSAGE%"  # Displays on IRC when someone sends a message on Dynmap.
 player-list: "We have (&l%COUNT%&r) players online. They are: %USERS%"  # The template used for the !players IRC command. If you make this blank, the command will be disabled.
+console-filters: # Filters messages that go into the staff channel. Format is regular expressions.
+    - "^\\[IRC\\].+"

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -442,6 +442,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			IRCd.msgDynmapMessage = messages.getString("dynmap-message", IRCd.msgDynmapMessage);
 			IRCd.msgPlayerList = messages.getString("player-list", IRCd.msgPlayerList);
 			
+			IRCd.consoleFilters = messages.getStringList("console-filters");
 			
 			//** RECOLOUR ALL MESSAGES **
 			

--- a/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
@@ -24,6 +24,11 @@ public class IRCCommandSender implements CommandSender {
 
     public void sendMessage(String message) {
     	if (enabled) {
+    			for (String filter : IRCd.consoleFilters){
+    				if (message.matches(filter)){
+    					return;
+    				}
+    			}
     			if (IRCd.mode == Modes.STANDALONE) IRCd.writeOpers(":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     			else if (IRCd.linkcompleted) IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     		}

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -186,6 +186,7 @@ public class IRCd implements Runnable {
 	public static List<BukkitPlayer> bukkitPlayers = new LinkedList<BukkitPlayer>();
 
 	public static List<String> MOTD = new ArrayList<String>();
+	public static List<String> consoleFilters = new ArrayList<String>();
 	public static List<IrcBan> ircBans = new ArrayList<IrcBan>();
 
 	public boolean running = true;


### PR DESCRIPTION
I couldn't think of a way to effectively fix #10, so I decided to make it more flexible so that users can change the formatting without breaking cancelling IRC messages in the staff channel.

It adds a StringList to messages.yml with regex strings. Loops over all of them and if it matches, cancels it. Includes regex `^\[IRC\].+` as a default, for the default formatting.
