### PR TITLE
Staff channel filters now support color

### DIFF
--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -477,7 +477,6 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 
 			IRCd.msgDynmapMessage = colorize(IRCd.msgDynmapMessage);
 			IRCd.msgPlayerList = colorize(IRCd.msgPlayerList);
-			
 
 			log.info("[BukkitIRCd] Loaded messages file. Code BukkitIRCdPlugin464.");
 		}

--- a/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
@@ -27,7 +27,7 @@ public class IRCCommandSender implements CommandSender {
     public void sendMessage(String message) {
     	if (enabled) {
     			for (String filter : IRCd.consoleFilters){
-    				if (ChatColor.stripColor(message).matches(filter)){
+    				if (message.matches(filter.replace('&', '\u00A7'))){ //Replace ampersands with section sign 
     					return;
     				}
     			}

--- a/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
@@ -1,6 +1,8 @@
 package com.Jdbye.BukkitIRCd;
 
 import java.util.Set;
+
+import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.permissions.PermissibleBase;
@@ -25,7 +27,7 @@ public class IRCCommandSender implements CommandSender {
     public void sendMessage(String message) {
     	if (enabled) {
     			for (String filter : IRCd.consoleFilters){
-    				if (message.matches(filter)){
+    				if (ChatColor.stripColor(message).matches(filter)){
     					return;
     				}
     			}


### PR DESCRIPTION
I just figured out how to do this, if you can see, initially, I just removed the colors, but now they support ampersand codes. Now a regex like `"^&3\\[IRC\\].+"` will block those pesky IRC join messages
