### PR TITLE
Make say and death messages show in chat.

### DIFF
--- a/res/config.yml
+++ b/res/config.yml
@@ -33,6 +33,8 @@ kick-commands:
 # Commands used to kick people
 handle-ampersand-colors: true
 # Whether to handle color codes with the & prefix
+broadcast-death-messages: true
+# Whether to broadcast death messages
 
 standalone:
     port: 6667  # Port to use for the standalone IRC server.

--- a/res/config.yml
+++ b/res/config.yml
@@ -33,6 +33,7 @@ kick-commands:
 # Commands used to kick people
 handle-ampersand-colors: true
 # Whether to handle color codes with the & prefix
+
 standalone:
     port: 6667  # Port to use for the standalone IRC server.
     max-connections: 1000  # Max number of simultaneous connections.

--- a/res/messages.yml
+++ b/res/messages.yml
@@ -38,8 +38,10 @@ group-prefixes: #Prefixes
   o: "&4"
   q: "&9"
   v: "&6"
+  user: ""
 group-suffixes: #Suffixes
   h: "|Mod"
   o: "|Admin"
   q: "|SuperAdmin"
   v: "|VIP"
+  user: "|User"

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -1,5 +1,6 @@
 package com.Jdbye.BukkitIRCd;
 
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -28,7 +29,7 @@ public class BukkitIRCdPlayerListener implements Listener {
 		
 		//Console Command Listener
 		String[] split = event.getCommand().split(" ");
-			
+		
 		if (split.length > 1){
 			
 			if (BukkitIRCdPlugin.kickCommands.contains(split[0].toLowerCase())){
@@ -43,7 +44,28 @@ public class BukkitIRCdPlayerListener implements Listener {
 					plugin.removeLastReceivedBy(kickedPlayer);
 					IRCd.kickBukkitUser(kickMessage, IRCd.getBukkitUser(kickedPlayer));
 			}
+			
+			if (split[0].equalsIgnoreCase("say")){
+				StringBuilder s = new StringBuilder(300);
+				for(int i = 1; i < split.length;i++){
+					 s.append(split[i]).append(" ");
+				}
+				
+				String message = s.toString();
+				if(IRCd.mode == Modes.INSPIRCD){
+					if (IRCd.linkcompleted)  {
+						IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+						}
+				}else{
+					IRCd.writeAll(ChatColor.stripColor(message));
+				}
+				
+			}
+			
 		}
+		
+		
+		
 	}
 	@EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event)
@@ -129,6 +151,27 @@ public class BukkitIRCdPlayerListener implements Listener {
 					
 					}
 				}
+			
+			if(split[0].equalsIgnoreCase("/say")){
+				if(event.getPlayer().hasPermission("bukkit.command.say")){
+					
+					StringBuilder s = new StringBuilder(300);
+					for(int i = 1; i < split.length;i++){
+						 s.append(split[i]).append(" ");
+					}
+					
+					String message = s.toString();
+					
+					if(IRCd.mode == Modes.INSPIRCD){
+						
+						if (IRCd.linkcompleted) { 
+							IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+							}
+					}else{
+						IRCd.writeAll(ChatColor.stripColor(message));
+					}
+				}
+			}
 				
 			}
 		}

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -23,7 +24,23 @@ public class BukkitIRCdPlayerListener implements Listener {
 		plugin = instance;
 	}
 
-	
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onPlayerDeath(PlayerDeathEvent event){
+		if (!IRCd.broadcastDeathMessages){
+			return; 
+		}
+		String message = event.getDeathMessage().replace(event.getEntity().getName(),event.getEntity().getName()+IRCd.ingameSuffix);
+		
+		if(IRCd.mode == Modes.INSPIRCD){
+			if (IRCd.linkcompleted)  {
+				
+				IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+				}
+		}else{
+			IRCd.writeAll(ChatColor.stripColor(message));
+		}
+		
+	}
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onServerCommand(ServerCommandEvent event){
 		

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -82,6 +82,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	private String ircd_consolechannel = "#staff";
 	private String ircd_irc_colors = "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15";
 	private String ircd_game_colors = "0,f,1,2,c,4,5,6,e,a,3,b,9,d,8,7";
+	private boolean ircd_broadcast_death_messages = true;
 	public static boolean debugmode = false;
 	public boolean dynmapEventRegistered = false;
 	
@@ -249,6 +250,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		IRCd.debugMode = debugmode;
 		IRCd.gameColors = ircd_game_colors.split(",");
 		IRCd.ircColors = convertStringArrayToIntArray(ircd_irc_colors.split(","), IRCd.ircColors);
+		IRCd.broadcastDeathMessages = ircd_broadcast_death_messages;
 		
 		// Linking specific settings
 		IRCd.remoteHost = link_remotehost;
@@ -354,7 +356,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			ircd_opermodes = config.getString("standalone.oper-modes", ircd_opermodes);
 			ircd_topic = config.getString("standalone.channel-topic", ircd_topic).replace("^K", (char)3 + "").replace("^B", (char)2 + "").replace("^I", (char)29 + "").replace("^O", (char)15 + "").replace("^U", (char)31 + "");
 			ircd_topicsetby = config.getString("standalone.channel-topic-set-by", ircd_topicsetby);
-
+			ircd_broadcast_death_messages = config.getBoolean("broadcast-death-messages",ircd_broadcast_death_messages);
 			try {
 				ircd_topicsetdate = dateFormat.parse(config.getString("standalone.channel-topic-set-date", dateFormat.format(ircd_topicsetdate))).getTime();
 			}

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -2557,7 +2557,8 @@ public class IRCd implements Runnable {
 		// Goes from highest rank to lowest rank
 		String prefix;
 		// Owner
-		if (modes.contains("q") || modes.contains("~")) {
+		
+		if (IRCd.groupPrefixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("q");
 			} catch (NullPointerException e) {
@@ -2571,7 +2572,7 @@ public class IRCd implements Runnable {
 		// replace("@", "o").replace("%", "h").replace("+", "v");
 
 		// Super Op
-		if (modes.contains("a") || modes.contains("&")) {
+		if (IRCd.groupPrefixes.contains("a") && (modes.contains("a") || modes.contains("&"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("a");
 			} catch (NullPointerException e) {
@@ -2583,7 +2584,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Op
-		if (modes.contains("o") || modes.contains("@")) {
+		if (IRCd.groupPrefixes.contains("o") && (modes.contains("o") || modes.contains("@"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("o");
 			} catch (NullPointerException e) {
@@ -2595,7 +2596,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Half Op
-		if (modes.contains("h") || modes.contains("%")) {
+		if (IRCd.groupPrefixes.contains("h") && (modes.contains("h") || modes.contains("%"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("h");
 			} catch (NullPointerException e) {
@@ -2607,7 +2608,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Voice
-		if (modes.contains("v") || modes.contains("+")) {
+		if (IRCd.groupPrefixes.contains("q") && (modes.contains("v") || modes.contains("+"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("v");
 			} catch (NullPointerException e) {
@@ -2619,6 +2620,7 @@ public class IRCd implements Runnable {
 		}
 		
 		// User
+		if (IRCd.groupPrefixes.contains("user")){
 			try {
 				prefix = IRCd.groupPrefixes.getString("user");
 			} catch (NullPointerException e) {
@@ -2628,6 +2630,7 @@ public class IRCd implements Runnable {
 				return ChatColor.translateAlternateColorCodes('&', prefix);
 			}
 			
+		}
 			return "";
 		
 	}
@@ -2642,7 +2645,7 @@ public class IRCd implements Runnable {
 		// Goes from highest rank to lowest rank
 		String suffix;
 		// Owner
-		if (modes.contains("q") || modes.contains("~")) {
+		if (IRCd.groupSuffixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
 			try {
 				suffix = IRCd.groupSuffixes.getString("q");
 			} catch (NullPointerException e) {
@@ -2656,7 +2659,7 @@ public class IRCd implements Runnable {
 		// replace("@", "o").replace("%", "h").replace("+", "v");
 
 		// Super Op
-		if (modes.contains("a") || modes.contains("&")) {
+		if (IRCd.groupSuffixes.contains("a") &&  (modes.contains("a") || modes.contains("&"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("a");
 			} catch (NullPointerException e) {
@@ -2668,7 +2671,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Op
-		if (modes.contains("o") || modes.contains("@")) {
+		if (IRCd.groupSuffixes.contains("o") &&  (modes.contains("o") || modes.contains("@"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("o");
 			} catch (NullPointerException e) {
@@ -2680,7 +2683,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Half Op
-		if (modes.contains("h") || modes.contains("%")) {
+		if (IRCd.groupSuffixes.contains("h") &&  (modes.contains("h") || modes.contains("%"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("h");
 			} catch (NullPointerException e) {
@@ -2692,7 +2695,7 @@ public class IRCd implements Runnable {
 		}
 
 		// Voice
-		if (modes.contains("v") || modes.contains("+")) {
+		if (IRCd.groupSuffixes.contains("v") && (modes.contains("v") || modes.contains("+"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("v");
 			} catch (NullPointerException e) {
@@ -2704,13 +2707,15 @@ public class IRCd implements Runnable {
 		}
 		
 		// User
-		try {
-			suffix = IRCd.groupSuffixes.getString("user");
-		} catch (NullPointerException e) {
-			return "";
-		}
-		if (!suffix.isEmpty() || suffix != null) {
-			return ChatColor.translateAlternateColorCodes('&', suffix);
+		if (IRCd.groupSuffixes.contains("user")) {
+			try {
+				suffix = IRCd.groupSuffixes.getString("user");
+			} catch (NullPointerException e) {
+				return "";
+			}
+			if (!suffix.isEmpty() || suffix != null) {
+				return ChatColor.translateAlternateColorCodes('&', suffix);
+			}
 		}
 		return "";
 		

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -173,6 +173,8 @@ public class IRCd implements Runnable {
 	public static boolean burstSent = false, capabSent = false;
 	public static boolean lastconnected = false;
 	public static boolean isIncoming = false;
+	public static boolean broadcastDeathMessages = true;
+
 
 	public static boolean isPlugin = false;
 


### PR DESCRIPTION
Because [this](https://github.com/WMCAlliance/BukkitIRCd/issues/10#issuecomment-16699069)

Death messages can be turned off by the `broadcast-death-messages` config.

Oh, and also fix an NPE that can happen if a user doesn't have a certain prefix or suffix in config.
