### PR TITLE
Add null checks, making colouring say and death toggleable, refactor commands into separate class files, and add PluginMetrics support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 			<version>1.2</version>
 			<type>jar</type>
 	    </dependency>
+	   
     </dependencies>
 
   <name>BukkitIRCd</name>

--- a/res/config.yml
+++ b/res/config.yml
@@ -35,7 +35,10 @@ handle-ampersand-colors: true
 # Whether to handle color codes with the & prefix
 broadcast-death-messages: true
 # Whether to broadcast death messages
-
+color-say-messages: false
+# Whether to make say messages colored
+color-death-messages: false
+# Whether to make death messages colored
 standalone:
     port: 6667  # Port to use for the standalone IRC server.
     max-connections: 1000  # Max number of simultaneous connections.

--- a/res/plugin.yml
+++ b/res/plugin.yml
@@ -11,42 +11,52 @@ commands:
     description: Lists the online users on IRC
     usage: /<command>
     aliases: [ilist]
+    permission: bukkitircd.list
   irckick:
     description: Kicks someone from IRC
     usage: /<command> nick (reason)
     aliases: [ikick]
+    permission: bukkitircd.kick
   ircban:
     description: Bans a user from IRC by their host, ip, ident, nick or a full hostmask 
     usage: /<command> (host/ip/ident/nick) nick/ip/fullhost (reason)
     aliases: [iban]
+    permission: bukkitircd.ban
   ircunban:
     description: Unbans someone from IRC by their IP or full hostmask
     usage: /<command> ip/fullhost
     aliases: [iunban]
+    permission: bukkitircd.unban
   ircwhois:
     description: Looks up someone on IRC
     usage: /<command> nick
     aliases: [iwhois]
+    permission: bukkitircd.whois
   ircmsg:
     description: Messages someone on IRC
     usage: /<command> nick message
     aliases: [imsg, im]
+    permission: bukkitircd.msg
   ircreply:
     description: Replies to the last IRC private message you received.
     usage: /<command> message
     aliases: [ireply, ir]
+    permission: bukkitircd.reply
   irctopic:
     description: Changes the IRC topic
     usage: /<command> newtopic
     aliases: [itopic]
+    permission: bukkitircd.topic
   irclink:
     description: Attempts to link to the remote server if in linking mode.
     usage: /<command>
     aliases: [ilink]
+    permission: bukkitircd.link
   ircreload:
     description: Reloads the configuration and MOTD.
     usage: /<command>
     aliases: [ireload]
+    permission: bukkitircd.reload
   rawsend:
     description: Sends a raw server command to the linked server, if enabled. Only usable from console.
     usage: /<command> command

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -31,13 +31,18 @@ public class BukkitIRCdPlayerListener implements Listener {
 		}
 		String message = event.getDeathMessage().replace(event.getEntity().getName(),event.getEntity().getName()+IRCd.ingameSuffix);
 		
+		if(!IRCd.colorDeathMessages){
+			message = ChatColor.stripColor(message);
+		}else{
+			message = IRCd.convertColors(message,false);
+		}
 		if(IRCd.mode == Modes.INSPIRCD){
 			if (IRCd.linkcompleted)  {
 				
-				IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+				IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + message);
 				}
 		}else{
-			IRCd.writeAll(ChatColor.stripColor(message));
+			IRCd.writeAll(message);
 		}
 		
 	}
@@ -69,12 +74,17 @@ public class BukkitIRCdPlayerListener implements Listener {
 				}
 				
 				String message = s.toString();
+				
+				message = ChatColor.stripColor(message);
+				if(IRCd.colorSayMessages){
+					message = (char) 3 + "13" + message;
+				}
 				if(IRCd.mode == Modes.INSPIRCD){
 					if (IRCd.linkcompleted)  {
-						IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+						IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + message);
 						}
 				}else{
-					IRCd.writeAll(ChatColor.stripColor(message));
+					IRCd.writeAll(message);
 				}
 				
 			}
@@ -179,13 +189,18 @@ public class BukkitIRCdPlayerListener implements Listener {
 					
 					String message = s.toString();
 					
+					message = ChatColor.stripColor(message);
+					if(IRCd.colorSayMessages){
+						message = (char) 3 + "13" + message;
+					}
+					
 					if(IRCd.mode == Modes.INSPIRCD){
 						
 						if (IRCd.linkcompleted) { 
-							IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + ChatColor.stripColor(message));
+							IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.channelName + " :" + message);
 							}
 					}else{
-						IRCd.writeAll(ChatColor.stripColor(message));
+						IRCd.writeAll(message);
 					}
 				}
 			}

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -31,6 +31,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.dynmap.DynmapAPI;
 import org.bukkit.ChatColor;
 
+import com.Jdbye.BukkitIRCd.commands.*;
 /**
  * BukkitIRCdPlugin for Bukkit
  *
@@ -56,7 +57,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	private static SimpleDateFormat dateFormat = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy");
 	public static String ircd_creationdate = dateFormat.format(curDate);
 
-	private Map<String, String> lastReceived = new HashMap<String, String>();
+	public Map<String, String> lastReceived = new HashMap<String, String>();
 
 	private int ircd_port = 6667;
 	private int ircd_maxconn = 1000;
@@ -103,7 +104,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public static List<String> kickCommands = Arrays.asList("/kick");
 	public static final Logger log = Logger.getLogger("Minecraft");
 	
-	private boolean enableRawSend = false;
+	public boolean enableRawSend = false;
 
 //	public static PermissionHandler permissionHandler = null;
 	public static DynmapAPI dynmap = null;
@@ -121,24 +122,26 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		PluginManager pm = getServer().getPluginManager();
 		pm.registerEvents(this.playerListener, this);
 		pm.registerEvents(this.serverListener, this);
-		/*
-		pm.registerEvent(Event.Type.PLAYER_JOIN, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLAYER_QUIT, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLAYER_KICK, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLAYER_CHAT, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLAYER_COMMAND_PREPROCESS, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLAYER_MOVE, this.playerListener, org.bukkit.event.Event.Priority.Monitor, this);
-		
-		pm.registerEvent(Event.Type.PLUGIN_ENABLE, this.serverListener, Event.Priority.Monitor, this);
-		pm.registerEvent(Event.Type.PLUGIN_DISABLE, this.serverListener, Event.Priority.Monitor, this);
-		*/
 		
 		PluginDescriptionFile pdfFile = getDescription();
 		ircd_version = pdfFile.getName() + " " + pdfFile.getVersion() + " by " + pdfFile.getAuthors().get(0);
 		setupMetrics();
 		pluginInit();
 
+		getCommand("ircban").setExecutor(new IRCBanCommand(this));
+		getCommand("irckick").setExecutor(new IRCKickCommand(this));
+		getCommand("irclist").setExecutor(new IRCListCommand(this));
+		getCommand("ircunban").setExecutor(new IRCUnbanCommand(this));
+		getCommand("ircwhois").setExecutor(new IRCWhoisCommand(this));
+		getCommand("ircmsg").setExecutor(new IRCMsgCommand(this));
+		getCommand("ircreply").setExecutor(new IRCReplyCommand(this));
+		getCommand("irctopic").setExecutor(new IRCTopicCommand(this));
+		getCommand("irclink").setExecutor(new IRCLinkCommand(this));
+		getCommand("ircreload").setExecutor(new IRCReloadCommand(this));
+		getCommand("rawsend").setExecutor(new RawsendCommand(this));
+		
 		log.info(ircd_version + " is enabled!");
+		
 	}
 	
 	public void onDisable() {
@@ -172,7 +175,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		pluginInit(false);
 	}
 	
-	private void pluginInit(boolean reload) {
+	public void pluginInit(boolean reload) {
 		if (reload) {
 			if (ircd != null) {
 				ircd.running = false;
@@ -292,12 +295,6 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		debugees.put(player, value);
 	}
 	
-//	public void unloadPermissions() {
-//		if (this.permissionHandler != null) {
-//			this.permissionHandler = null;
-//			log.info("[BukkitIRCd] Permissions plugin lost.");
-//		}
-//	}
 	
 	// check for Dynmap, and if it's installed, register events and hooks
 	private void setupDynmap() {
@@ -779,511 +776,6 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		}
 	}
 
-	// The current structure for commands. At some point I'd like to improve this
-	@Override
-	public boolean onCommand(CommandSender sender, Command command, String commandLabel, String[] args) {
-		if (!isEnabled()) { return true; }
-		String commandName = command.getName().toLowerCase();
-		String[] trimmedArgs = args;
-
-
-
-		if (sender instanceof Player) {
-			Player player = (Player)sender;
-			if (commandName.equalsIgnoreCase("irclist") || commandName.equalsIgnoreCase("ilist")) {
-				if (hasPermission(player, "bukkitircd.list")) {
-					String players[] = IRCd.getIRCNicks();
-					String allplayers = "";
-					for (String curplayer : players) allplayers += ChatColor.GRAY + curplayer + ChatColor.WHITE + ", ";
-					player.sendMessage(ChatColor.BLUE + "There are " + ChatColor.RED + players.length + ChatColor.BLUE + " users on IRC.");
-					if (players.length > 0) player.sendMessage(allplayers.substring(0,allplayers.length()-2));
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irckick") || commandName.equalsIgnoreCase("ikick")) {
-				if (hasPermission(player, "bukkitircd.kick")) {
-					if (trimmedArgs.length > 0) {
-						String reason = null;
-						if (trimmedArgs.length > 1) reason = IRCd.join(trimmedArgs, " ", 1);
-						IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-						if (ircuser != null) {
-							if (IRCd.kickIRCUser(ircuser, player.getName(), player.getName(), player.getAddress().getAddress().getHostName(), reason, true))
-								player.sendMessage(ChatColor.RED + "Player kicked.");
-							else
-								player.sendMessage(ChatColor.RED + "Failed to kick player.");
-						}
-						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a nickname and optionally a kick reason."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircban") || commandName.equalsIgnoreCase("iban")) {
-				if (hasPermission(player, "bukkitircd.ban")) {
-					if (trimmedArgs.length > 0) {
-						String reason = null;
-						IRCUser ircuser;
-						String ban;
-						String banType = null;
-						if ((trimmedArgs[0].equalsIgnoreCase("ip")) || (trimmedArgs[0].equalsIgnoreCase("host")) || (trimmedArgs[0].equalsIgnoreCase("ident")) || (trimmedArgs[0].equalsIgnoreCase("nick"))) {
-							ircuser = IRCd.getIRCUser(trimmedArgs[1]);
-							ban = trimmedArgs[1];
-							banType = trimmedArgs[0];
-							if (trimmedArgs.length > 2) reason = IRCd.join(trimmedArgs, " ", 2);
-						}
-						else {
-							ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-							ban = trimmedArgs[0];
-							if (trimmedArgs.length > 1) reason = IRCd.join(trimmedArgs, " ", 1);
-						}
-						if (IRCd.wildCardMatch(ban, "*!*@*")) {
-							// Full hostmask
-							if (IRCd.banIRCUser(ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
-								if (IRCd.msgIRCBan.length() > 0) getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								if ((dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								player.sendMessage(ChatColor.RED + "User banned.");
-							}
-							else player.sendMessage(ChatColor.RED + "User is already banned.");
-						}
-						else if (countStr(ban, ".") == 3) { // It's an IP
-							if (IRCd.banIRCUser("*!*@" + ban, player.getName() + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
-								if (IRCd.msgIRCBan.length() > 0) getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								if ((dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								player.sendMessage(ChatColor.RED + "IP banned.");
-							}
-							else
-								player.sendMessage(ChatColor.RED + "IP is already banned.");
-						}
-						else {
-							if (ircuser != null) {
-								if (IRCd.kickBanIRCUser(ircuser, player.getName(), player.getName() + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName(), reason, true, banType))
-									player.sendMessage(ChatColor.RED + "User banned.");
-								else
-									player.sendMessage(ChatColor.RED + "User is already banned.");
-							}
-							else { player.sendMessage(ChatColor.RED + "That user is not online."); }
-						}
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a nickname or IP and optionally a ban reason."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircunban") || commandName.equalsIgnoreCase("iunban")) {
-				if (hasPermission(player, "bukkitircd.unban")) {
-					if (trimmedArgs.length > 0) {
-						String ban;
-						ban = trimmedArgs[0];
-						if (trimmedArgs.length > 1)
-							IRCd.join(trimmedArgs, " ", 1);
-
-						if (IRCd.wildCardMatch(ban, "*!*@*")) { // Full hostmask
-							if (IRCd.unBanIRCUser(ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
-								if (IRCd.msgIRCUnban.length() > 0) getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								if ((dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								player.sendMessage(ChatColor.RED + "User unbanned.");
-							}
-							else
-								player.sendMessage(ChatColor.RED + "User is not banned.");
-						}
-						else if (countStr(ban, ".") == 3) { // It's an IP
-							if (IRCd.unBanIRCUser("*!*@" + ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
-								if (IRCd.msgIRCUnban.length() > 0) getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								if ((dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
-								player.sendMessage(ChatColor.RED + "IP unbanned.");
-							}
-							else
-								player.sendMessage(ChatColor.RED + "IP is not banned.");
-						} 
-						else { player.sendMessage(ChatColor.RED + "Invalid hostmask."); return false; }
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a IP/full hostmask."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircwhois") || commandName.equalsIgnoreCase("iwhois")) {
-				if (hasPermission(player, "bukkitircd.whois")) {
-					if (trimmedArgs.length > 0) {
-						IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-						if (ircuser != null) {
-							String[] whois = IRCd.getIRCWhois(ircuser);
-							if (whois != null) {
-								for (String whoisline : whois) player.sendMessage(whoisline);
-							}
-						}
-						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a nickname."); return false; }		}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircmsg") || commandName.equalsIgnoreCase("imsg") || commandName.equalsIgnoreCase("im")) {
-				if (hasPermission(player, "bukkitircd.msg")) {
-					if (trimmedArgs.length > 1) {
-						IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-						if (ircuser != null) {
-							if (IRCd.mode == Modes.STANDALONE) { 
-								IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 1), false));
-								player.sendMessage(ChatColor.RED + "Message sent.");
-							}
-							else if (IRCd.mode == Modes.INSPIRCD) {
-								BukkitPlayer bp;
-								if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
-									String UID = IRCd.getUIDFromIRCUser(ircuser);
-									if (UID != null) {
-										if (IRCd.linkcompleted) {
-											IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 1), false));
-											player.sendMessage(ChatColor.RED + "Message sent.");
-										}
-										else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
-									}
-									else {
-										log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-										player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-									}
-								}
-								else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
-							}
-						}
-						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}    		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircreply") || commandName.equalsIgnoreCase("ireply") || commandName.equalsIgnoreCase("ir")) {
-				if (hasPermission(player, "bukkitircd.reply")) {
-					if (trimmedArgs.length > 0) {
-						String lastReceivedFrom = lastReceived.get(player.getName());
-						if (lastReceivedFrom == null) {
-							player.sendMessage(ChatColor.RED + "There are no messages to reply to!");
-						}
-						else {
-							IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
-							if (ircuser != null) {
-								if (IRCd.mode == Modes.STANDALONE) {
-									IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 0), false));
-									player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-								}
-								else if (IRCd.mode == Modes.INSPIRCD) {
-									BukkitPlayer bp;
-									if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
-										String UID = IRCd.getUIDFromIRCUser(ircuser);
-										if (UID != null) {
-											if (IRCd.linkcompleted) {
-												IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 0), false));
-												player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-											} else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
-										}
-										else {
-											log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-											player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-										}
-									}
-									else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
-								}
-							}
-							else { player.sendMessage(ChatColor.RED + "That user is not online."); }
-						}
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}    			
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irctopic") || commandName.equalsIgnoreCase("itopic")) {
-				if (hasPermission(player, "bukkitircd.topic")) {
-					if (trimmedArgs.length > 0) {
-						String topic = IRCd.join(trimmedArgs, " ", 0);
-						String playername = player.getName();
-						String playerhost = player.getAddress().getAddress().getHostName();
-						IRCd.setTopic(IRCd.convertColors(topic, false), playername + IRCd.ingameSuffix, playername + IRCd.ingameSuffix + "!" + playername + "@" + playerhost);
-						player.sendMessage(ChatColor.RED + "Topic set to " + topic);
-					}
-					else { player.sendMessage(ChatColor.RED + "Please provide a topic to set."); return false; }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}    		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irclink") || commandName.equalsIgnoreCase("ilink")) {
-				if (hasPermission(player, "bukkitircd.link")) {
-					if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-						if ((!IRCd.linkcompleted) && (!IRCd.isConnected())) {
-							if (IRCd.connect()) player.sendMessage(ChatColor.RED + "Successfully connected to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
-							else player.sendMessage(ChatColor.RED + "Failed to connect to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
-						}
-						else {
-							if (IRCd.linkcompleted) player.sendMessage(ChatColor.RED + "Already linked to " + IRCd.linkName + ".");
-							else player.sendMessage(ChatColor.RED + "Already connected to " + IRCd.linkName + ", but not linked.");
-						}
-					}
-					else { player.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircreload") || commandName.equalsIgnoreCase("ireload")) {
-				if (hasPermission(player, "bukkitircd.reload")) {
-					pluginInit(true);
-					log.info("[BukkitIRCd] Configuration file reloaded.");
-					player.sendMessage(ChatColor.RED + "Configuration file reloaded.");
-				}
-				else {
-					player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-				}
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("rawsend")) {
-				if (enableRawSend) {
-					sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Only the console can use this command.");
-				}
-				else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Sending raw messages is disabled. Please enable them in the config first."); }
-				return true;
-			}
-		}
-		else {
-			if (commandName.equalsIgnoreCase("irclist") || commandName.equalsIgnoreCase("ilist")) {
-				String players[] = IRCd.getIRCNicks();
-				String allplayers = "";
-				for (String curplayer : players) allplayers += ChatColor.GRAY + curplayer + ChatColor.WHITE + ", ";
-				sender.sendMessage(ChatColor.BLUE + "There are " + ChatColor.RED + players.length + ChatColor.BLUE + " users on IRC.");
-				if (players.length > 0) sender.sendMessage(allplayers.substring(0,allplayers.length()-2));
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irckick") || commandName.equalsIgnoreCase("ikick")) {
-				if (trimmedArgs.length > 0) {
-					String reason = null;
-					if (trimmedArgs.length > 1) reason = IRCd.join(trimmedArgs, " ", 1);
-					IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-					if (ircuser != null) {
-						if (IRCd.kickIRCUser(ircuser, IRCd.serverName, IRCd.serverName, IRCd.serverHostName, reason, false)) sender.sendMessage(ChatColor.RED + "Player kicked.");
-						else sender.sendMessage(ChatColor.RED + "Failed to kick player.");
-						
-					}
-					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and optionally a kick reason."); return false; }		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircban") || commandName.equalsIgnoreCase("iban")) {
-				if (trimmedArgs.length > 0) {
-					String reason = null;
-					IRCUser ircuser;
-					String ban;
-					String banType = null;
-					if ((trimmedArgs[0].equalsIgnoreCase("ip")) || (trimmedArgs[0].equalsIgnoreCase("host")) || (trimmedArgs[0].equalsIgnoreCase("ident")) || (trimmedArgs[0].equalsIgnoreCase("nick"))) {
-						ircuser = IRCd.getIRCUser(trimmedArgs[1]);
-						ban = trimmedArgs[1];
-						banType = trimmedArgs[0];
-						if (trimmedArgs.length > 2) reason = IRCd.join(trimmedArgs, " ", 2);
-					}
-					else {
-						ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-						ban = trimmedArgs[0];
-						if (trimmedArgs.length > 1) reason = IRCd.join(trimmedArgs, " ", 1);
-					}
-					if (IRCd.wildCardMatch(ban, "*!*@*")) {
-						// Full hostmask
-						if (IRCd.banIRCUser(ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
-							if (IRCd.msgIRCBan.length() > 0) getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							if ((dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							sender.sendMessage(ChatColor.RED + "User banned.");
-						}
-						else
-							sender.sendMessage(ChatColor.RED + "User is already banned.");
-					}
-					else if (countStr(ban, ".") == 3) { // It's an IP
-						if (IRCd.banIRCUser("*!*@" + ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
-							if (IRCd.msgIRCBan.length() > 0) getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							if ((dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							sender.sendMessage(ChatColor.RED + "IP banned.");
-						}
-						else
-							sender.sendMessage(ChatColor.RED + "IP is already banned.");
-					}
-					else {
-						if (ircuser != null) {
-							if (IRCd.kickBanIRCUser(ircuser, "server", IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName, reason, true, banType))
-								sender.sendMessage(ChatColor.RED + "User banned.");
-							else
-								sender.sendMessage(ChatColor.RED + "User is already banned.");
-						}
-						else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
-					}
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a nickname or IP and optionally a ban reason."); return false; }
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircunban") || commandName.equalsIgnoreCase("iunban")) {
-				if (trimmedArgs.length > 0) {
-					String ban;
-					ban = trimmedArgs[0];
-					if (trimmedArgs.length > 1)
-						IRCd.join(trimmedArgs, " ", 1);
-
-					if (IRCd.wildCardMatch(ban, "*!*@*")) { // Full hostmask
-						if (IRCd.unBanIRCUser(ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
-							if (IRCd.msgIRCUnban.length() > 0) getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							if ((dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							sender.sendMessage(ChatColor.RED + "User unbanned.");
-						}
-						else
-							sender.sendMessage(ChatColor.RED + "User is not banned.");
-					}
-					else if (countStr(ban, ".") == 3) { // It's an IP
-						if (IRCd.unBanIRCUser("*!*@" + ban, IRCd.serverName+"!" + IRCd.serverName+"@" + IRCd.serverHostName)) {
-							if (IRCd.msgIRCUnban.length() > 0) getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							if ((dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
-							sender.sendMessage(ChatColor.RED + "IP unbanned.");
-						}
-						else
-							sender.sendMessage(ChatColor.RED + "IP is not banned.");
-					} 
-					else { sender.sendMessage(ChatColor.RED + "Invalid hostmask."); return false; }
-
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a IP/full hostmask."); return false; }
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircwhois") || commandName.equalsIgnoreCase("iwhois")) {
-				if (trimmedArgs.length > 0) {
-					IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-					if (ircuser != null) {
-						String[] whois = IRCd.getIRCWhois(ircuser);
-						for (String whoisline : whois) sender.sendMessage(whoisline);
-					}
-					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a nickname."); return false; }		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircmsg") || commandName.equalsIgnoreCase("imsg") || commandName.equalsIgnoreCase("im")) {
-				if (trimmedArgs.length > 1) {
-					IRCUser ircuser = IRCd.getIRCUser(trimmedArgs[0]);
-					if (ircuser != null) {
-						if (IRCd.mode == Modes.STANDALONE) {
-							IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 1),false));
-							sender.sendMessage(ChatColor.RED + "Message sent.");
-						}
-						else if (IRCd.mode == Modes.INSPIRCD) {
-							String UID = IRCd.getUIDFromIRCUser(ircuser);
-							if (UID != null) {
-								if (IRCd.linkcompleted) {
-									IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 1), false));
-									sender.sendMessage(ChatColor.RED + "Message sent.");
-								} else sender.sendMessage(ChatColor.DARK_RED + "Failed to send message, not currently linked to IRC server.");
-							}
-							else {
-								log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-								sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-							}
-						}
-					}
-					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircreply") || commandName.equalsIgnoreCase("ireply") || commandName.equalsIgnoreCase("ir")) {
-				if (trimmedArgs.length > 0) {
-					String lastReceivedFrom = lastReceived.get("@CONSOLE@");
-					if (lastReceivedFrom == null) {
-						sender.sendMessage(ChatColor.RED + "There are no messages to reply to!");
-					}
-					else {
-						IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
-						if (ircuser != null) {
-							if (IRCd.mode == Modes.STANDALONE) {
-								IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 0),false));
-								sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-							}
-							else if (IRCd.mode == Modes.INSPIRCD) {
-								String UID = IRCd.getUIDFromIRCUser(ircuser);
-								if (UID != null) {
-									if (IRCd.linkcompleted) {
-										IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(trimmedArgs, " ", 0), false));
-										sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-									} else sender.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
-								}
-								else {
-									log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-									sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-								}
-							}
-						}
-						else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
-					}
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irctopic") || commandName.equalsIgnoreCase("itopic")) {
-				if (trimmedArgs.length > 0) {
-					String topic = IRCd.join(trimmedArgs, " ", 0);
-					IRCd.setTopic(IRCd.convertColors(topic, false), IRCd.serverName, ircd_servername + "!" + ircd_servername + "@" + ircd_serverhostname);
-					sender.sendMessage(ChatColor.RED + "Topic set to " + topic);
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a topic to set."); return false; }		
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("irclink") || commandName.equalsIgnoreCase("ilink")) {
-				if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-					if ((!IRCd.linkcompleted) && (!IRCd.isConnected())) {
-						if (IRCd.connect()) sender.sendMessage(ChatColor.RED + "Successfully connected to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
-						else sender.sendMessage(ChatColor.RED + "Failed to connect to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
-					}
-					else {
-						if (IRCd.linkcompleted) sender.sendMessage(ChatColor.RED + "Already linked to " + IRCd.linkName + ".");
-						else sender.sendMessage(ChatColor.RED + "Already connected to " + IRCd.linkName + ", but not linked.");
-					}
-				}
-				else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("ircreload") || commandName.equalsIgnoreCase("ireload")) {
-				pluginInit(true);
-				log.info("[BukkitIRCd] Configuration file reloaded.");
-				sender.sendMessage(ChatColor.RED + "Configuration file reloaded.");
-				return true;
-			}
-			else if (commandName.equalsIgnoreCase("rawsend")) {
-				if (enableRawSend) {
-					if (trimmedArgs.length > 0) {
-						if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-							if (IRCd.println(IRCd.join(trimmedArgs, " ", 0))) sender.sendMessage(ChatColor.RED + "Command sent to IRC server link.");
-							else sender.sendMessage(ChatColor.RED + "Failed to send command to IRC server link, not currently linked.");
-						}
-					}
-					else { sender.sendMessage(ChatColor.RED + "Please provide a command to send."); return false; }
-				}
-				else { sender.sendMessage(ChatColor.RED + "Rawsend is not enabled."); }
-				return true;
-			}
-		}
-		return false;
-	}
 
 	public boolean hasPermission(Player player, String permission)
 	{

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -82,6 +82,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	private String ircd_consolechannel = "#staff";
 	private String ircd_irc_colors = "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15";
 	private String ircd_game_colors = "0,f,1,2,c,4,5,6,e,a,3,b,9,d,8,7";
+	private boolean ircd_color_death_messages = false;
+	private boolean ircd_color_say_messages = false;
 	private boolean ircd_broadcast_death_messages = true;
 	public static boolean debugmode = false;
 	public boolean dynmapEventRegistered = false;
@@ -133,11 +135,12 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		
 		PluginDescriptionFile pdfFile = getDescription();
 		ircd_version = pdfFile.getName() + " " + pdfFile.getVersion() + " by " + pdfFile.getAuthors().get(0);
-
+		setupMetrics();
 		pluginInit();
 
 		log.info(ircd_version + " is enabled!");
 	}
+	
 	public void onDisable() {
 		if (ircd != null) {
 			ircd.running = false;
@@ -251,7 +254,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		IRCd.gameColors = ircd_game_colors.split(",");
 		IRCd.ircColors = convertStringArrayToIntArray(ircd_irc_colors.split(","), IRCd.ircColors);
 		IRCd.broadcastDeathMessages = ircd_broadcast_death_messages;
-		
+		IRCd.colorDeathMessages = ircd_color_death_messages;
+		IRCd.colorSayMessages = ircd_color_say_messages;
 		// Linking specific settings
 		IRCd.remoteHost = link_remotehost;
 		IRCd.remotePort = link_remoteport;
@@ -326,6 +330,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 
 	private void loadSettings() {
 		try {
+			ircd_color_death_messages = config.getBoolean("color-death-messages", ircd_color_death_messages);
+			ircd_color_say_messages = config.getBoolean("color-say-messages", ircd_color_say_messages);
 			mode = config.getString("mode", mode);
 			ircd_ingamesuffix = config.getString("ingame-suffix", ircd_ingamesuffix);
 			ircd_enablenotices = config.getBoolean("enable-notices", ircd_enablenotices);
@@ -1351,6 +1357,18 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			}
 		} catch (Exception e) { log.severe("[BukkitIRCd] Unable to parse string array " + IRCd.join(sarray, " ", 0) + ", invalid number. " + e); }
 		return def;
+	}
+	
+	/**
+	 * Setup PluginMetrics
+	 */
+	private void setupMetrics(){
+		try {
+		    Metrics metrics = new Metrics(this);
+		    metrics.start();
+		} catch (IOException e) {
+		    // Failed to submit metrics
+		}
 	}
 }
 

--- a/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCCommandSender.java
@@ -1,6 +1,7 @@
 package com.Jdbye.BukkitIRCd;
 
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
@@ -25,16 +26,24 @@ public class IRCCommandSender implements CommandSender {
     }
 
     public void sendMessage(String message) {
-    	if (enabled) {
-    			for (String filter : IRCd.consoleFilters){
-    				if (message.matches(filter.replace('&', '\u00A7'))){ //Replace ampersands with section sign 
-    					return;
-    				}
-    			}
+		if (enabled) {
+			for (String filter : IRCd.consoleFilters) {
+				try {
+					if (message.matches(filter.replace('&', '\u00A7'))) { // Replace Ampersands with section signs
+						return;
+					}
+				} catch (PatternSyntaxException e) {
+					BukkitIRCdPlugin.thePlugin.getLogger().warning("Invalid Regex Found at console-filters");
+					continue;
+				}
+			}
+		}
+    	
+
     			if (IRCd.mode == Modes.STANDALONE) IRCd.writeOpers(":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     			else if (IRCd.linkcompleted) IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + IRCd.consoleChannelName + " :" + IRCd.convertColors(message, false));
     		}
-    	}
+    	
     
     
     public void sendMessage(String[] message) {

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -2560,6 +2560,9 @@ public class IRCd implements Runnable {
 		String prefix;
 		// Owner
 		
+		if(IRCd.groupPrefixes == null){
+			return "";
+		}
 		if (IRCd.groupPrefixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("q");
@@ -2646,6 +2649,10 @@ public class IRCd implements Runnable {
 	public static String getGroupSuffix(String modes) {
 		// Goes from highest rank to lowest rank
 		String suffix;
+		
+		if (IRCd.groupSuffixes == null){
+			return "";
+		}
 		// Owner
 		if (IRCd.groupSuffixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
 			try {

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -174,7 +174,8 @@ public class IRCd implements Runnable {
 	public static boolean lastconnected = false;
 	public static boolean isIncoming = false;
 	public static boolean broadcastDeathMessages = true;
-
+	public static boolean colorDeathMessages = false;
+	public static boolean colorSayMessages = false;
 
 	public static boolean isPlugin = false;
 
@@ -219,6 +220,7 @@ public class IRCd implements Runnable {
 
 	public static BufferedReader in;
 	public static PrintStream out;
+	
 
 	public IRCd() {
 	}

--- a/src/com/Jdbye/BukkitIRCd/Metrics.java
+++ b/src/com/Jdbye/BukkitIRCd/Metrics.java
@@ -1,0 +1,651 @@
+/*
+ * Copyright 2011-2013 Tyler Blair. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *       of conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are those of the
+ * authors and contributors and should not be interpreted as representing official policies,
+ * either expressed or implied, of anybody else.
+ */
+package com.Jdbye.BukkitIRCd;
+
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginDescriptionFile;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
+
+/**
+ * <p> The metrics class obtains data about a plugin and submits statistics about it to the metrics backend. </p> <p>
+ * Public methods provided by this class: </p>
+ * <code>
+ * Graph createGraph(String name); <br/>
+ * void addCustomData(BukkitMetrics.Plotter plotter); <br/>
+ * void start(); <br/>
+ * </code>
+ */
+public class Metrics {
+
+    /**
+     * The current revision number
+     */
+    private final static int REVISION = 6;
+    /**
+     * The base url of the metrics domain
+     */
+    private static final String BASE_URL = "http://mcstats.org";
+    /**
+     * The url used to report a server's status
+     */
+    private static final String REPORT_URL = "/report/%s";
+    /**
+     * The separator to use for custom data. This MUST NOT change unless you are hosting your own version of metrics and
+     * want to change it.
+     */
+    private static final String CUSTOM_DATA_SEPARATOR = "~~";
+    /**
+     * Interval of time to ping (in minutes)
+     */
+    private static final int PING_INTERVAL = 10;
+    /**
+     * The plugin this metrics submits for
+     */
+    private final Plugin plugin;
+    /**
+     * All of the custom graphs to submit to metrics
+     */
+    private final Set<Graph> graphs = Collections.synchronizedSet(new HashSet<Graph>());
+    /**
+     * The default graph, used for addCustomData when you don't want a specific graph
+     */
+    private final Graph defaultGraph = new Graph("Default");
+    /**
+     * The plugin configuration file
+     */
+    private final YamlConfiguration configuration;
+    /**
+     * The plugin configuration file
+     */
+    private final File configurationFile;
+    /**
+     * Unique server id
+     */
+    private final String guid;
+    /**
+     * Debug mode
+     */
+    private final boolean debug;
+    /**
+     * Lock for synchronization
+     */
+    private final Object optOutLock = new Object();
+    /**
+     * The scheduled task
+     */
+    private volatile BukkitTask task = null;
+
+    public Metrics(final Plugin plugin) throws IOException {
+        if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        }
+
+        this.plugin = plugin;
+
+        // load the config
+        configurationFile = getConfigFile();
+        configuration = YamlConfiguration.loadConfiguration(configurationFile);
+
+        // add some defaults
+        configuration.addDefault("opt-out", false);
+        configuration.addDefault("guid", UUID.randomUUID().toString());
+        configuration.addDefault("debug", false);
+
+        // Do we need to create the file?
+        if (configuration.get("guid", null) == null) {
+            configuration.options().header("http://mcstats.org").copyDefaults(true);
+            configuration.save(configurationFile);
+        }
+
+        // Load the guid then
+        guid = configuration.getString("guid");
+        debug = configuration.getBoolean("debug", false);
+    }
+
+    /**
+     * Construct and create a Graph that can be used to separate specific plotters to their own graphs on the metrics
+     * website. Plotters can be added to the graph object returned.
+     *
+     * @param name The name of the graph
+     * @return Graph object created. Will never return NULL under normal circumstances unless bad parameters are given
+     */
+    public Graph createGraph(final String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("Graph name cannot be null");
+        }
+
+        // Construct the graph object
+        final Graph graph = new Graph(name);
+
+        // Now we can add our graph
+        graphs.add(graph);
+
+        // and return back
+        return graph;
+    }
+
+    /**
+     * Add a Graph object to BukkitMetrics that represents data for the plugin that should be sent to the backend
+     *
+     * @param graph The name of the graph
+     */
+    public void addGraph(final Graph graph) {
+        if (graph == null) {
+            throw new IllegalArgumentException("Graph cannot be null");
+        }
+
+        graphs.add(graph);
+    }
+
+    /**
+     * Adds a custom data plotter to the default graph
+     *
+     * @param plotter The plotter to use to plot custom data
+     */
+    public void addCustomData(final Plotter plotter) {
+        if (plotter == null) {
+            throw new IllegalArgumentException("Plotter cannot be null");
+        }
+
+        // Add the plotter to the graph o/
+        defaultGraph.addPlotter(plotter);
+
+        // Ensure the default graph is included in the submitted graphs
+        graphs.add(defaultGraph);
+    }
+
+    /**
+     * Start measuring statistics. This will immediately create an async repeating task as the plugin and send the
+     * initial data to the metrics backend, and then after that it will post in increments of PING_INTERVAL * 1200
+     * ticks.
+     *
+     * @return True if statistics measuring is running, otherwise false.
+     */
+    public boolean start() {
+        synchronized (optOutLock) {
+            // Did we opt out?
+            if (isOptOut()) {
+                return false;
+            }
+
+            // Is metrics already running?
+            if (task != null) {
+                return true;
+            }
+
+            // Begin hitting the server with glorious data
+            task = plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, new Runnable() {
+
+                private boolean firstPost = true;
+
+                public void run() {
+                    try {
+                        // This has to be synchronized or it can collide with the disable method.
+                        synchronized (optOutLock) {
+                            // Disable Task, if it is running and the server owner decided to opt-out
+                            if (isOptOut() && task != null) {
+                                task.cancel();
+                                task = null;
+                                // Tell all plotters to stop gathering information.
+                                for (Graph graph : graphs) {
+                                    graph.onOptOut();
+                                }
+                            }
+                        }
+
+                        // We use the inverse of firstPost because if it is the first time we are posting,
+                        // it is not a interval ping, so it evaluates to FALSE
+                        // Each time thereafter it will evaluate to TRUE, i.e PING!
+                        postPlugin(!firstPost);
+
+                        // After the first post we set firstPost to false
+                        // Each post thereafter will be a ping
+                        firstPost = false;
+                    } catch (IOException e) {
+                        if (debug) {
+                            Bukkit.getLogger().log(Level.INFO, "[Metrics] " + e.getMessage());
+                        }
+                    }
+                }
+            }, 0, PING_INTERVAL * 1200);
+
+            return true;
+        }
+    }
+
+    /**
+     * Has the server owner denied plugin metrics?
+     *
+     * @return true if metrics should be opted out of it
+     */
+    public boolean isOptOut() {
+        synchronized (optOutLock) {
+            try {
+                // Reload the metrics file
+                configuration.load(getConfigFile());
+            } catch (IOException ex) {
+                if (debug) {
+                    Bukkit.getLogger().log(Level.INFO, "[Metrics] " + ex.getMessage());
+                }
+                return true;
+            } catch (InvalidConfigurationException ex) {
+                if (debug) {
+                    Bukkit.getLogger().log(Level.INFO, "[Metrics] " + ex.getMessage());
+                }
+                return true;
+            }
+            return configuration.getBoolean("opt-out", false);
+        }
+    }
+
+    /**
+     * Enables metrics for the server by setting "opt-out" to false in the config file and starting the metrics task.
+     *
+     * @throws java.io.IOException
+     */
+    public void enable() throws IOException {
+        // This has to be synchronized or it can collide with the check in the task.
+        synchronized (optOutLock) {
+            // Check if the server owner has already set opt-out, if not, set it.
+            if (isOptOut()) {
+                configuration.set("opt-out", false);
+                configuration.save(configurationFile);
+            }
+
+            // Enable Task, if it is not running
+            if (task == null) {
+                start();
+            }
+        }
+    }
+
+    /**
+     * Disables metrics for the server by setting "opt-out" to true in the config file and canceling the metrics task.
+     *
+     * @throws java.io.IOException
+     */
+    public void disable() throws IOException {
+        // This has to be synchronized or it can collide with the check in the task.
+        synchronized (optOutLock) {
+            // Check if the server owner has already set opt-out, if not, set it.
+            if (!isOptOut()) {
+                configuration.set("opt-out", true);
+                configuration.save(configurationFile);
+            }
+
+            // Disable Task, if it is running
+            if (task != null) {
+                task.cancel();
+                task = null;
+            }
+        }
+    }
+
+    /**
+     * Gets the File object of the config file that should be used to store data such as the GUID and opt-out status
+     *
+     * @return the File object for the config file
+     */
+    public File getConfigFile() {
+        // I believe the easiest way to get the base folder (e.g craftbukkit set via -P) for plugins to use
+        // is to abuse the plugin object we already have
+        // plugin.getDataFolder() => base/plugins/PluginA/
+        // pluginsFolder => base/plugins/
+        // The base is not necessarily relative to the startup directory.
+        File pluginsFolder = plugin.getDataFolder().getParentFile();
+
+        // return => base/plugins/PluginMetrics/config.yml
+        return new File(new File(pluginsFolder, "PluginMetrics"), "config.yml");
+    }
+
+    /**
+     * Generic method that posts a plugin to the metrics website
+     */
+    private void postPlugin(final boolean isPing) throws IOException {
+        // Server software specific section
+        PluginDescriptionFile description = plugin.getDescription();
+        String pluginName = description.getName();
+        boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
+        String pluginVersion = description.getVersion();
+        String serverVersion = Bukkit.getVersion();
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+
+        // END server software specific section -- all code below does not use any code outside of this class / Java
+
+        // Construct the post data
+        final StringBuilder data = new StringBuilder();
+
+        // The plugin's description file containg all of the plugin data such as name, version, author, etc
+        data.append(encode("guid")).append('=').append(encode(guid));
+        encodeDataPair(data, "version", pluginVersion);
+        encodeDataPair(data, "server", serverVersion);
+        encodeDataPair(data, "players", Integer.toString(playersOnline));
+        encodeDataPair(data, "revision", String.valueOf(REVISION));
+
+        // New data as of R6
+        String osname = System.getProperty("os.name");
+        String osarch = System.getProperty("os.arch");
+        String osversion = System.getProperty("os.version");
+        String java_version = System.getProperty("java.version");
+        int coreCount = Runtime.getRuntime().availableProcessors();
+
+        // normalize os arch .. amd64 -> x86_64
+        if (osarch.equals("amd64")) {
+            osarch = "x86_64";
+        }
+
+        encodeDataPair(data, "osname", osname);
+        encodeDataPair(data, "osarch", osarch);
+        encodeDataPair(data, "osversion", osversion);
+        encodeDataPair(data, "cores", Integer.toString(coreCount));
+        encodeDataPair(data, "online-mode", Boolean.toString(onlineMode));
+        encodeDataPair(data, "java_version", java_version);
+
+        // If we're pinging, append it
+        if (isPing) {
+            encodeDataPair(data, "ping", "true");
+        }
+
+        // Acquire a lock on the graphs, which lets us make the assumption we also lock everything
+        // inside of the graph (e.g plotters)
+        synchronized (graphs) {
+            final Iterator<Graph> iter = graphs.iterator();
+
+            while (iter.hasNext()) {
+                final Graph graph = iter.next();
+
+                for (Plotter plotter : graph.getPlotters()) {
+                    // The key name to send to the metrics server
+                    // The format is C-GRAPHNAME-PLOTTERNAME where separator - is defined at the top
+                    // Legacy (R4) submitters use the format Custom%s, or CustomPLOTTERNAME
+                    final String key = String.format("C%s%s%s%s", CUSTOM_DATA_SEPARATOR, graph.getName(), CUSTOM_DATA_SEPARATOR, plotter.getColumnName());
+
+                    // The value to send, which for the foreseeable future is just the string
+                    // value of plotter.getValue()
+                    final String value = Integer.toString(plotter.getValue());
+
+                    // Add it to the http post data :)
+                    encodeDataPair(data, key, value);
+                }
+            }
+        }
+
+        // Create the url
+        URL url = new URL(BASE_URL + String.format(REPORT_URL, encode(pluginName)));
+
+        // Connect to the website
+        URLConnection connection;
+
+        // Mineshafter creates a socks proxy, so we can safely bypass it
+        // It does not reroute POST requests so we need to go around it
+        if (isMineshafterPresent()) {
+            connection = url.openConnection(Proxy.NO_PROXY);
+        } else {
+            connection = url.openConnection();
+        }
+
+        connection.setDoOutput(true);
+
+        // Write the data
+        final OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+        writer.write(data.toString());
+        writer.flush();
+
+        // Now read the response
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        final String response = reader.readLine();
+
+        // close resources
+        writer.close();
+        reader.close();
+
+        if (response == null || response.startsWith("ERR")) {
+            throw new IOException(response); //Throw the exception
+        } else {
+            // Is this the first update this hour?
+            if (response.contains("OK This is your first update this hour")) {
+                synchronized (graphs) {
+                    final Iterator<Graph> iter = graphs.iterator();
+
+                    while (iter.hasNext()) {
+                        final Graph graph = iter.next();
+
+                        for (Plotter plotter : graph.getPlotters()) {
+                            plotter.reset();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if mineshafter is present. If it is, we need to bypass it to send POST requests
+     *
+     * @return true if mineshafter is installed on the server
+     */
+    private boolean isMineshafterPresent() {
+        try {
+            Class.forName("mineshafter.MineServer");
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * <p>Encode a key/value data pair to be used in a HTTP post request. This INCLUDES a & so the first key/value pair
+     * MUST be included manually, e.g:</p>
+     * <code>
+     * StringBuffer data = new StringBuffer();
+     * data.append(encode("guid")).append('=').append(encode(guid));
+     * encodeDataPair(data, "version", description.getVersion());
+     * </code>
+     *
+     * @param buffer the stringbuilder to append the data pair onto
+     * @param key the key value
+     * @param value the value
+     */
+    private static void encodeDataPair(final StringBuilder buffer, final String key, final String value) throws UnsupportedEncodingException {
+        buffer.append('&').append(encode(key)).append('=').append(encode(value));
+    }
+
+    /**
+     * Encode text as UTF-8
+     *
+     * @param text the text to encode
+     * @return the encoded text, as UTF-8
+     */
+    private static String encode(final String text) throws UnsupportedEncodingException {
+        return URLEncoder.encode(text, "UTF-8");
+    }
+
+    /**
+     * Represents a custom graph on the website
+     */
+    public static class Graph {
+
+        /**
+         * The graph's name, alphanumeric and spaces only :) If it does not comply to the above when submitted, it is
+         * rejected
+         */
+        private final String name;
+        /**
+         * The set of plotters that are contained within this graph
+         */
+        private final Set<Plotter> plotters = new LinkedHashSet<Plotter>();
+
+        private Graph(final String name) {
+            this.name = name;
+        }
+
+        /**
+         * Gets the graph's name
+         *
+         * @return the Graph's name
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Add a plotter to the graph, which will be used to plot entries
+         *
+         * @param plotter the plotter to add to the graph
+         */
+        public void addPlotter(final Plotter plotter) {
+            plotters.add(plotter);
+        }
+
+        /**
+         * Remove a plotter from the graph
+         *
+         * @param plotter the plotter to remove from the graph
+         */
+        public void removePlotter(final Plotter plotter) {
+            plotters.remove(plotter);
+        }
+
+        /**
+         * Gets an <b>unmodifiable</b> set of the plotter objects in the graph
+         *
+         * @return an unmodifiable {@link java.util.Set} of the plotter objects
+         */
+        public Set<Plotter> getPlotters() {
+            return Collections.unmodifiableSet(plotters);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            if (!(object instanceof Graph)) {
+                return false;
+            }
+
+            final Graph graph = (Graph) object;
+            return graph.name.equals(name);
+        }
+
+        /**
+         * Called when the server owner decides to opt-out of BukkitMetrics while the server is running.
+         */
+        protected void onOptOut() {
+        }
+    }
+
+    /**
+     * Interface used to collect custom data for a plugin
+     */
+    public static abstract class Plotter {
+
+        /**
+         * The plot's name
+         */
+        private final String name;
+
+        /**
+         * Construct a plotter with the default plot name
+         */
+        public Plotter() {
+            this("Default");
+        }
+
+        /**
+         * Construct a plotter with a specific plot name
+         *
+         * @param name the name of the plotter to use, which will show up on the website
+         */
+        public Plotter(final String name) {
+            this.name = name;
+        }
+
+        /**
+         * Get the current value for the plotted point. Since this function defers to an external function it may or may
+         * not return immediately thus cannot be guaranteed to be thread friendly or safe. This function can be called
+         * from any thread so care should be taken when accessing resources that need to be synchronized.
+         *
+         * @return the current value for the point to be plotted.
+         */
+        public abstract int getValue();
+
+        /**
+         * Get the column name for the plotted point
+         *
+         * @return the plotted point's column name
+         */
+        public String getColumnName() {
+            return name;
+        }
+
+        /**
+         * Called after the website graphs have been updated
+         */
+        public void reset() {
+        }
+
+        @Override
+        public int hashCode() {
+            return getColumnName().hashCode();
+        }
+
+        @Override
+        public boolean equals(final Object object) {
+            if (!(object instanceof Plotter)) {
+                return false;
+            }
+
+            final Plotter plotter = (Plotter) object;
+            return plotter.name.equals(name) && plotter.getValue() == getValue();
+        }
+    }
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCBanCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCBanCommand.java
@@ -1,0 +1,126 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCUser;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCBanCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCBanCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.ban")) {
+				if (args.length > 0) {
+					String reason = null;
+					IRCUser ircuser;
+					String ban;
+					String banType = null;
+					if ((args[0].equalsIgnoreCase("ip")) || (args[0].equalsIgnoreCase("host")) || (args[0].equalsIgnoreCase("ident")) || (args[0].equalsIgnoreCase("nick"))) {
+						ircuser = IRCd.getIRCUser(args[1]);
+						ban = args[1];
+						banType = args[0];
+						if (args.length > 2) reason = IRCd.join(args, " ", 2);
+					}
+					else {
+						ircuser = IRCd.getIRCUser(args[0]);
+						ban = args[0];
+						if (args.length > 1) reason = IRCd.join(args, " ", 1);
+					}
+					if (IRCd.wildCardMatch(ban, "*!*@*")) {
+						// Full hostmask
+						if (IRCd.banIRCUser(ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
+							if (IRCd.msgIRCBan.length() > 0) thePlugin.thePlugin.getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							if ((BukkitIRCdPlugin.dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) BukkitIRCdPlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							player.sendMessage(ChatColor.RED + "User banned.");
+						}
+						else player.sendMessage(ChatColor.RED + "User is already banned.");
+					}
+					else if (thePlugin.countStr(ban, ".") == 3) { // It's an IP
+						if (IRCd.banIRCUser("*!*@" + ban, player.getName() + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
+							if (IRCd.msgIRCBan.length() > 0) thePlugin.thePlugin.getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							if ((BukkitIRCdPlugin.dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) BukkitIRCdPlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							player.sendMessage(ChatColor.RED + "IP banned.");
+						}
+						else
+							player.sendMessage(ChatColor.RED + "IP is already banned.");
+					}
+					else {
+						if (ircuser != null) {
+							if (IRCd.kickBanIRCUser(ircuser, player.getName(), player.getName() + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName(), reason, true, banType))
+								player.sendMessage(ChatColor.RED + "User banned.");
+							else
+								player.sendMessage(ChatColor.RED + "User is already banned.");
+						}
+						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+					}
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a nickname or IP and optionally a ban reason."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			if (args.length > 0) {
+				String reason = null;
+				IRCUser ircuser;
+				String ban;
+				String banType = null;
+				if ((args[0].equalsIgnoreCase("ip")) || (args[0].equalsIgnoreCase("host")) || (args[0].equalsIgnoreCase("ident")) || (args[0].equalsIgnoreCase("nick"))) {
+					ircuser = IRCd.getIRCUser(args[1]);
+					ban = args[1];
+					banType = args[0];
+					if (args.length > 2) reason = IRCd.join(args, " ", 2);
+				}
+				else {
+					ircuser = IRCd.getIRCUser(args[0]);
+					ban = args[0];
+					if (args.length > 1) reason = IRCd.join(args, " ", 1);
+				}
+				if (IRCd.wildCardMatch(ban, "*!*@*")) {
+					// Full hostmask
+					if (IRCd.banIRCUser(ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
+						if (IRCd.msgIRCBan.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						if ((thePlugin.dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						sender.sendMessage(ChatColor.RED + "User banned.");
+					}
+					else
+						sender.sendMessage(ChatColor.RED + "User is already banned.");
+				}
+				else if (thePlugin.countStr(ban, ".") == 3) { // It's an IP
+					if (IRCd.banIRCUser("*!*@" + ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
+						if (IRCd.msgIRCBan.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCBan.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						if ((thePlugin.dynmap != null) && (IRCd.msgIRCBanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCBanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						sender.sendMessage(ChatColor.RED + "IP banned.");
+					}
+					else
+						sender.sendMessage(ChatColor.RED + "IP is already banned.");
+				}
+				else {
+					if (ircuser != null) {
+						if (IRCd.kickBanIRCUser(ircuser, "server", IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName, reason, true, banType))
+							sender.sendMessage(ChatColor.RED + "User banned.");
+						else
+							sender.sendMessage(ChatColor.RED + "User is already banned.");
+					}
+					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+				}
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname or IP and optionally a ban reason."); return false; }
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCKickCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCKickCommand.java
@@ -1,0 +1,60 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCUser;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCKickCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCKickCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.kick")) {
+				if (args.length > 0) {
+					String reason = null;
+					if (args.length > 1) reason = IRCd.join(args, " ", 1);
+					IRCUser ircuser = IRCd.getIRCUser(args[0]);
+					if (ircuser != null) {
+						if (IRCd.kickIRCUser(ircuser, player.getName(), player.getName(), player.getAddress().getAddress().getHostName(), reason, true))
+							player.sendMessage(ChatColor.RED + "Player kicked.");
+						else
+							player.sendMessage(ChatColor.RED + "Failed to kick player.");
+					}
+					else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a nickname and optionally a kick reason."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			if (args.length > 0) {
+				String reason = null;
+				if (args.length > 1) reason = IRCd.join(args, " ", 1);
+				IRCUser ircuser = IRCd.getIRCUser(args[0]);
+				if (ircuser != null) {
+					if (IRCd.kickIRCUser(ircuser, IRCd.serverName, IRCd.serverName, IRCd.serverHostName, reason, false)) sender.sendMessage(ChatColor.RED + "Player kicked.");
+					else sender.sendMessage(ChatColor.RED + "Failed to kick player.");
+					
+				}
+				else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and optionally a kick reason."); return false; }		
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCLinkCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCLinkCommand.java
@@ -1,0 +1,58 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCd;
+import com.Jdbye.BukkitIRCd.Modes;
+
+public class IRCLinkCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCLinkCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.link")) {
+				if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
+					if ((!IRCd.linkcompleted) && (!IRCd.isConnected())) {
+						if (IRCd.connect()) player.sendMessage(ChatColor.RED + "Successfully connected to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
+						else player.sendMessage(ChatColor.RED + "Failed to connect to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
+					}
+					else {
+						if (IRCd.linkcompleted) player.sendMessage(ChatColor.RED + "Already linked to " + IRCd.linkName + ".");
+						else player.sendMessage(ChatColor.RED + "Already connected to " + IRCd.linkName + ", but not linked.");
+					}
+				}
+				else { player.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			
+			if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
+				if ((!IRCd.linkcompleted) && (!IRCd.isConnected())) {
+					if (IRCd.connect()) sender.sendMessage(ChatColor.RED + "Successfully connected to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
+					else sender.sendMessage(ChatColor.RED + "Failed to connect to " + IRCd.remoteHost + " on port " + IRCd.remotePort);
+				}
+				else {
+					if (IRCd.linkcompleted) sender.sendMessage(ChatColor.RED + "Already linked to " + IRCd.linkName + ".");
+					else sender.sendMessage(ChatColor.RED + "Already connected to " + IRCd.linkName + ", but not linked.");
+				}
+			}
+			else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCListCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCListCommand.java
@@ -1,0 +1,44 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCListCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCListCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.list")) {
+				String players[] = IRCd.getIRCNicks();
+				String allplayers = "";
+				for (String curplayer : players) allplayers += ChatColor.GRAY + curplayer + ChatColor.WHITE + ", ";
+				player.sendMessage(ChatColor.BLUE + "There are " + ChatColor.RED + players.length + ChatColor.BLUE + " users on IRC.");
+				if (players.length > 0) player.sendMessage(allplayers.substring(0,allplayers.length()-2));
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			String players[] = IRCd.getIRCNicks();
+			String allplayers = "";
+			for (String curplayer : players) allplayers += ChatColor.GRAY + curplayer + ChatColor.WHITE + ", ";
+			sender.sendMessage(ChatColor.BLUE + "There are " + ChatColor.RED + players.length + ChatColor.BLUE + " users on IRC.");
+			if (players.length > 0) sender.sendMessage(allplayers.substring(0,allplayers.length()-2));
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
@@ -1,0 +1,91 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.BukkitPlayer;
+import com.Jdbye.BukkitIRCd.IRCUser;
+import com.Jdbye.BukkitIRCd.IRCd;
+import com.Jdbye.BukkitIRCd.Modes;
+
+public class IRCMsgCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCMsgCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.msg")) {
+				if (args.length > 1) {
+					IRCUser ircuser = IRCd.getIRCUser(args[0]);
+					if (ircuser != null) {
+						if (IRCd.mode == Modes.STANDALONE) { 
+							IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
+							player.sendMessage(ChatColor.RED + "Message sent.");
+						}
+						else if (IRCd.mode == Modes.INSPIRCD) {
+							BukkitPlayer bp;
+							if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
+								String UID = IRCd.getUIDFromIRCUser(ircuser);
+								if (UID != null) {
+									if (IRCd.linkcompleted) {
+										IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
+										player.sendMessage(ChatColor.RED + "Message sent.");
+									}
+									else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
+								}
+								else {
+									BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
+									player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+								}
+							}
+							else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
+						}
+					}
+					else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}    		
+			return true;
+		}else{
+			if (args.length > 1) {
+				IRCUser ircuser = IRCd.getIRCUser(args[0]);
+				if (ircuser != null) {
+					if (IRCd.mode == Modes.STANDALONE) {
+						IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 1),false));
+						sender.sendMessage(ChatColor.RED + "Message sent.");
+					}
+					else if (IRCd.mode == Modes.INSPIRCD) {
+						String UID = IRCd.getUIDFromIRCUser(ircuser);
+						if (UID != null) {
+							if (IRCd.linkcompleted) {
+								IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
+								sender.sendMessage(ChatColor.RED + "Message sent.");
+							} else sender.sendMessage(ChatColor.DARK_RED + "Failed to send message, not currently linked to IRC server.");
+						}
+						else {
+							BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
+							sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+						}
+					}
+				}
+				else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
+			return true;
+		}
+		
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCReloadCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCReloadCommand.java
@@ -1,0 +1,39 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+
+public class IRCReloadCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCReloadCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.reload")) {
+				thePlugin.pluginInit(true);
+				BukkitIRCdPlugin.log.info("[BukkitIRCd] Configuration file reloaded.");
+				player.sendMessage(ChatColor.RED + "Configuration file reloaded.");
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			thePlugin.pluginInit(true);
+			BukkitIRCdPlugin.log.info("[BukkitIRCd] Configuration file reloaded.");
+			sender.sendMessage(ChatColor.RED + "Configuration file reloaded.");
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
@@ -1,0 +1,101 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.BukkitPlayer;
+import com.Jdbye.BukkitIRCd.IRCUser;
+import com.Jdbye.BukkitIRCd.IRCd;
+import com.Jdbye.BukkitIRCd.Modes;
+
+public class IRCReplyCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCReplyCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.reply")) {
+				if (args.length > 0) {
+					String lastReceivedFrom = thePlugin.lastReceived.get(player.getName());
+					if (lastReceivedFrom == null) {
+						player.sendMessage(ChatColor.RED + "There are no messages to reply to!");
+					}
+					else {
+						IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
+						if (ircuser != null) {
+							if (IRCd.mode == Modes.STANDALONE) {
+								IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
+								player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
+							}
+							else if (IRCd.mode == Modes.INSPIRCD) {
+								BukkitPlayer bp;
+								if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
+									String UID = IRCd.getUIDFromIRCUser(ircuser);
+									if (UID != null) {
+										if (IRCd.linkcompleted) {
+											IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
+											player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
+										} else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
+									}
+									else {
+										BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
+										player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+									}
+								}
+								else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
+							}
+						}
+						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+					}
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}    			
+			return true;
+		}else{
+			if (args.length > 0) {
+				String lastReceivedFrom = thePlugin.lastReceived.get("@CONSOLE@");
+				if (lastReceivedFrom == null) {
+					sender.sendMessage(ChatColor.RED + "There are no messages to reply to!");
+				}
+				else {
+					IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
+					if (ircuser != null) {
+						if (IRCd.mode == Modes.STANDALONE) {
+							IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 0),false));
+							sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
+						}
+						else if (IRCd.mode == Modes.INSPIRCD) {
+							String UID = IRCd.getUIDFromIRCUser(ircuser);
+							if (UID != null) {
+								if (IRCd.linkcompleted) {
+									IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
+									sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
+								} else sender.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
+							}
+							else {
+								BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
+								sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+							}
+						}
+					}
+					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+				}
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCTopicCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCTopicCommand.java
@@ -1,0 +1,48 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCTopicCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCTopicCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.topic")) {
+				if (args.length > 0) {
+					String topic = IRCd.join(args, " ", 0);
+					String playername = player.getName();
+					String playerhost = player.getAddress().getAddress().getHostName();
+					IRCd.setTopic(IRCd.convertColors(topic, false), playername + IRCd.ingameSuffix, playername + IRCd.ingameSuffix + "!" + playername + "@" + playerhost);
+					player.sendMessage(ChatColor.RED + "Topic set to " + topic);
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a topic to set."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}    		
+			return true;
+		}else{
+			if (args.length > 0) {
+				String topic = IRCd.join(args, " ", 0);
+				IRCd.setTopic(IRCd.convertColors(topic, false), IRCd.serverName, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName);
+				sender.sendMessage(ChatColor.RED + "Topic set to " + topic);
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a topic to set."); return false; }		
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCUnbanCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCUnbanCommand.java
@@ -1,0 +1,92 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCUnbanCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCUnbanCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			
+			if (player.hasPermission("bukkitircd.unban")) {
+				if (args.length > 0) {
+					String ban;
+					ban = args[0];
+					if (args.length > 1)
+						IRCd.join(args, " ", 1);
+
+					if (IRCd.wildCardMatch(ban, "*!*@*")) { // Full hostmask
+						if (IRCd.unBanIRCUser(ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
+							if (IRCd.msgIRCUnban.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							if ((thePlugin.dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							player.sendMessage(ChatColor.RED + "User unbanned.");
+						}
+						else
+							player.sendMessage(ChatColor.RED + "User is not banned.");
+					}
+					else if (thePlugin.countStr(ban, ".") == 3) { // It's an IP
+						if (IRCd.unBanIRCUser("*!*@" + ban, player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName())) {
+							if (IRCd.msgIRCUnban.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							if ((thePlugin.dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%",player.getName()));
+							player.sendMessage(ChatColor.RED + "IP unbanned.");
+						}
+						else
+							player.sendMessage(ChatColor.RED + "IP is not banned.");
+					} 
+					else { player.sendMessage(ChatColor.RED + "Invalid hostmask."); return false; }
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a IP/full hostmask."); return false; }
+			}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+			
+		}else{
+			if (args.length > 0) {
+				String ban;
+				ban = args[0];
+				if (args.length > 1)
+					IRCd.join(args, " ", 1);
+
+				if (IRCd.wildCardMatch(ban, "*!*@*")) { // Full hostmask
+					if (IRCd.unBanIRCUser(ban, IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName)) {
+						if (IRCd.msgIRCUnban.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						if ((thePlugin.dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						sender.sendMessage(ChatColor.RED + "User unbanned.");
+					}
+					else
+						sender.sendMessage(ChatColor.RED + "User is not banned.");
+				}
+				else if (thePlugin.countStr(ban, ".") == 3) { // It's an IP
+					if (IRCd.unBanIRCUser("*!*@" + ban, IRCd.serverName+"!" + IRCd.serverName+"@" + IRCd.serverHostName)) {
+						if (IRCd.msgIRCUnban.length() > 0) thePlugin.getServer().broadcastMessage(IRCd.msgIRCUnban.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						if ((thePlugin.dynmap != null) && (IRCd.msgIRCUnbanDynmap.length() > 0)) thePlugin.dynmap.sendBroadcastToWeb("IRC", IRCd.msgIRCUnbanDynmap.replace("%BANNEDUSER%", ban).replace("%BANNEDBY%","console"));
+						sender.sendMessage(ChatColor.RED + "IP unbanned.");
+					}
+					else
+						sender.sendMessage(ChatColor.RED + "IP is not banned.");
+				} 
+				else { sender.sendMessage(ChatColor.RED + "Invalid hostmask."); return false; }
+
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a IP/full hostmask."); return false; }
+			return true;
+			
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCWhoisCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCWhoisCommand.java
@@ -1,0 +1,54 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCUser;
+import com.Jdbye.BukkitIRCd.IRCd;
+
+public class IRCWhoisCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public IRCWhoisCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			Player player = (Player) sender;
+			if (player.hasPermission("bukkitircd.whois")) {
+				if (args.length > 0) {
+					IRCUser ircuser = IRCd.getIRCUser(args[0]);
+					if (ircuser != null) {
+						String[] whois = IRCd.getIRCWhois(ircuser);
+						if (whois != null) {
+							for (String whoisline : whois) player.sendMessage(whoisline);
+						}
+					}
+					else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+				}
+				else { player.sendMessage(ChatColor.RED + "Please provide a nickname."); return false; }		}
+			else {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+			}
+			return true;
+		}else{
+			if (args.length > 0) {
+				IRCUser ircuser = IRCd.getIRCUser(args[0]);
+				if (ircuser != null) {
+					String[] whois = IRCd.getIRCWhois(ircuser);
+					for (String whoisline : whois) sender.sendMessage(whoisline);
+				}
+				else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+			}
+			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname."); return false; }		
+			return true;
+		}
+	}
+
+}

--- a/src/com/Jdbye/BukkitIRCd/commands/RawsendCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/RawsendCommand.java
@@ -1,0 +1,45 @@
+package com.Jdbye.BukkitIRCd.commands;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
+import com.Jdbye.BukkitIRCd.IRCd;
+import com.Jdbye.BukkitIRCd.Modes;
+
+public class RawsendCommand implements CommandExecutor{
+
+	private BukkitIRCdPlugin thePlugin;
+
+	public RawsendCommand(BukkitIRCdPlugin plugin) {
+		this.thePlugin = plugin;
+	}
+	public boolean onCommand(CommandSender sender, Command cmd, String label,
+			String[] args) {
+		if (sender instanceof Player){
+			sender = (Player) sender;
+			if (thePlugin.enableRawSend) {
+				sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Only the console can use this command.");
+			}
+			else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Sending raw messages is disabled. Please enable them in the config first."); }
+			return true;
+		
+		}else{
+			if (thePlugin.enableRawSend) {
+				if (args.length > 0) {
+					if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
+						if (IRCd.println(IRCd.join(args, " ", 0))) sender.sendMessage(ChatColor.RED + "Command sent to IRC server link.");
+						else sender.sendMessage(ChatColor.RED + "Failed to send command to IRC server link, not currently linked.");
+					}
+				}
+				else { sender.sendMessage(ChatColor.RED + "Please provide a command to send."); return false; }
+			}
+			else { sender.sendMessage(ChatColor.RED + "Rawsend is not enabled."); }
+			return true;
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes issue #34 and adds option to change whether say and death messages are coloured. 

Also cleans up `onCommand()` by putting each command into a separate class file
This also adds PluginMetrics to collect stats for the plugin. Note, metrics haven't been sent to MCStats.org since I had metrics disabled when testing the plugin.
