### PR TITLE
Fix #38 and allow pre-/suff-ixes to used in kick messages

### DIFF
--- a/res/messages.yml
+++ b/res/messages.yml
@@ -9,8 +9,8 @@ irc-leave: "&3[IRC] &e%PREFIX%%USER%%SUFFIX%&r left IRC"  # Displays ingame when
 irc-leave-reason: "&3[IRC] &e%PREFIX%%USER%%SUFFIX%&r left IRC (%REASON%)"  # Displays ingame when someone leaves IRC with a reason.
 irc-leave-dynmap: "%USER% left IRC"  # Displays on dynmap when someone leaves IRC.
 irc-leave-reason-dynmap: "%USER% left IRC (%REASON%)"  # Displays on dynmap when someone leaves IRC with a reason.
-irc-kick: "&3[IRC] &e%KICKEDUSER% was kicked by %KICKEDBY%"  # Displays ingame when someone is kicked from IRC.
-irc-kick-reason: "&3[IRC] &e%KICKEDUSER% was kicked by %KICKEDBY% (%REASON%)"  # Displays ingame when someone is kicked from IRC with a reason.
+irc-kick: "&3[IRC] &r%KICKEDPREFIX%%KICKEDUSER%%KICKEDSUFFIX%&r was kicked by &r%KICKERPREFIX%%KICKEDBY%%KICKERSUFFIX%&r"  # Displays ingame when someone is kicked from IRC.
+irc-kick-reason: "&3[IRC] &r%KICKEDPREFIX%%KICKEDUSER%%KICKEDSUFFIX%&r was kicked by %KICKERPREFIX%%KICKEDBY%%KICKERSUFFIX%&r (%REASON%)"  # Displays ingame when someone is kicked from IRC with a reason.
 irc-kick-dynmap: "%KICKEDUSER% was kicked by %KICKEDBY%"  # Displays on dynmap when someone is kicked from IRC.
 irc-kick-reason-dynmap: "%KICKEDUSER% was kicked by %KICKEDBY% (%REASON%)"  # Displays on dynmap when someone is kicked from IRC with a reason.
 irc-ban: "&3[IRC] &e%BANNEDUSER% was banned by %BANNEDBY%"  # Displays ingame when someone is banned from IRC.
@@ -19,12 +19,10 @@ irc-ban-dynmap: "%BANNEDUSER% was banned by %BANNEDBY%"  # Displays on dynmap wh
 irc-unban-dynmap: "%BANNEDUSER% was unbanned by %BANNEDBY%"  # Displays on dynmap when someone is unbanned from IRC.
 irc-nick-change: "&3[IRC] &e%PREFIX%%OLDNICK%%SUFFIX%&r is now known as %PREFIX%%NEWNICK%%SUFFIX%&r"  # Displays ingame when someone changes their nick on IRC.
 irc-nick-change-dynmap: "%OLDNICK% is now known as %NEWNICK%"  # Displays on dynmap when someone changes their nick on IRC.
-irc-action: "&r[IRC] * &7%PREFIX%%USER%%SUFFIX%&r %MESSAGE%"  # Displays ingame when someone sends an action on IRC.
-irc-message: "&r[IRC] <&7%PREFIX%%USER%%SUFFIX%&r> %MESSAGE%"  # Displays ingame when someone sends a message on IRC.
-irc-notice: "&r[IRC] -&7%PREFIX%%USER%%SUFFIX%&r- %MESSAGE%"  # Displays ingame when someone sends a notice on IRC.
-irc-private-action: "&r[IRC] &aTo you&r: * &7%PREFIX%%USER%%SUFFIX%&r %MESSAGE%"  # Displays ingame when someone sends a private action on IRC.
-irc-private-message: "&r[IRC] &aTo you&r: <&7%PREFIX%%USER%%SUFFIX%&r> %MESSAGE%"  # Displays ingame when someone sends a private message on IRC.
-irc-private-notice: "&r[IRC] &aTo you&r: -&7%PREFIX%%USER%%SUFFIX%&r- %MESSAGE%"  # Displays ingame when someone sends a private notice on IRC.
+irc-private-action: "&r[IRC] &6[&r%PREFIX%%USER%%SUFFIX%&r &6-> me]&r %MESSAGE%"  # Displays ingame when someone sends a private action on IRC.
+irc-private-message: "&r[IRC] &6[&r%PREFIX%%USER%%SUFFIX%&r &6-> me]&r %MESSAGE%"  # Displays ingame when someone sends a private message on IRC.
+irc-private-notice: "&r[IRC] &6[&r%PREFIX%%USER%%SUFFIX%&r &6-> me] &r%MESSAGE%"  # Displays ingame when someone sends a private notice on IRC.
+irc-send-pm: "&r[IRC] &6[me -> %PREFIX%%USER%%SUFFIX%&6]&r %MESSAGE%"  # Displays ingame when ingame player send someone a private message to IRC.
 irc-action-dynmap: "* %USER% %MESSAGE%"  # Displays on dynmap when someone sends an action on IRC.
 irc-message-dynmap: "<%USER%> %MESSAGE%"  # Displays on dynmap when someone sends a message on IRC.
 irc-notice-dynmap: "-%USER%- %MESSAGE%"  # Displays on dynmap when someone sends a notice on IRC.

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -425,6 +425,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		try {
 			IRCd.msgLinked = messages.getString("linked", IRCd.msgLinked);
 			
+			IRCd.msgSendQueryFromIngame = messages.getString("irc-send-pm", IRCd.msgSendQueryFromIngame);
 			IRCd.msgDelinked = messages.getString("delinked", IRCd.msgDelinked);
 			IRCd.msgDelinkedReason = messages.getString("delinked-reason", IRCd.msgDelinkedReason);
 			
@@ -471,6 +472,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			IRCd.consoleFilters = messages.getStringList("console-filters");
 			//** RECOLOUR ALL MESSAGES **
 			
+			IRCd.msgSendQueryFromIngame = colorize(IRCd.msgSendQueryFromIngame);
 			IRCd.msgLinked = colorize(IRCd.msgLinked);
 			IRCd.msgDelinked = colorize(IRCd.msgDelinked);
 			IRCd.msgDelinkedReason = colorize(IRCd.msgDelinked);

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -126,6 +126,7 @@ public class IRCd implements Runnable {
 	public static int SID = 111;
 
 	// Custom messages
+	public static String msgSendQueryFromIngame = "&r[IRC] [me -> &7%PREFIX%%USER%%SUFFIX%&r] %MESSAGE%";
 	public static String msgLinked = "&e[IRC] Linked to server %LINKNAME%";
 	public static String msgDelinked = "&e[IRC] Split from server %LINKNAME%";
 	public static String msgDelinkedReason = "&e[IRC] Split from server %LINKNAME% (%REASON%)";

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -220,7 +220,6 @@ public class IRCd implements Runnable {
 
 	public static BufferedReader in;
 	public static PrintStream out;
-	
 
 	public IRCd() {
 	}
@@ -1251,7 +1250,25 @@ public class IRCd implements Runnable {
 																		"%REASON%",
 																		convertColors(
 																				reason,
-																				true)));
+																				true))
+																.replace(
+																		"%KICKEDPREFIX%",
+																		IRCd.getGroupPrefix(processor.modes))
+																.replace(
+																		"%KICKEDSUFFIX%",
+																		IRCd.getGroupSuffix(processor.modes))
+																.replace(
+																		"%KICKERPREFIX%",
+																		IRCd.getGroupPrefix(IRCd
+																				.getIRCUser(
+																						kickedByNick)
+																				.getTextModes()))
+																.replace(
+																		"%KICKERSUFFIX%",
+																		IRCd.getGroupSuffix(IRCd
+																				.getIRCUser(
+																						kickedByNick)
+																				.getTextModes())));
 									if ((BukkitIRCdPlugin.dynmap != null)
 											&& (msgIRCKickReasonDynmap.length() > 0))
 										BukkitIRCdPlugin.dynmap
@@ -1278,7 +1295,25 @@ public class IRCd implements Runnable {
 																		processor.nick)
 																.replace(
 																		"%KICKEDBY%",
-																		kickedByNick));
+																		kickedByNick)
+																.replace(
+																		"%KICKEDPREFIX%",
+																		IRCd.getGroupPrefix(processor.modes))
+																.replace(
+																		"%KICKEDSUFFIX%",
+																		IRCd.getGroupSuffix(processor.modes))
+																.replace(
+																		"%KICKERPREFIX%",
+																		IRCd.getGroupPrefix(IRCd
+																				.getIRCUser(
+																						kickedByNick)
+																				.getTextModes()))
+																.replace(
+																		"%KICKERSUFFIX%",
+																		IRCd.getGroupSuffix(IRCd
+																				.getIRCUser(
+																						kickedByNick)
+																				.getTextModes())));
 									if ((BukkitIRCdPlugin.dynmap != null)
 											&& (msgIRCKickDynmap.length() > 0))
 										BukkitIRCdPlugin.dynmap
@@ -1370,7 +1405,8 @@ public class IRCd implements Runnable {
 							println(":" + sourceUID + " KICK " + channelName
 									+ " " + uid + " :" + reason);
 							if (msgIRCKickReason.length() > 0)
-								BukkitIRCdPlugin.thePlugin.getServer()
+								BukkitIRCdPlugin.thePlugin
+										.getServer()
 										.broadcastMessage(
 												msgIRCKickReason
 														.replace(
@@ -1382,7 +1418,27 @@ public class IRCd implements Runnable {
 																"%REASON%",
 																convertColors(
 																		reason,
-																		true)));
+																		true))
+														.replace(
+																"%KICKEDPREFIX%",
+																IRCd.getGroupPrefix(iuser
+																		.getTextModes()))
+														.replace(
+																"%KICKEDSUFFIX%",
+																IRCd.getGroupSuffix(iuser
+																		.getTextModes()))
+														.replace(
+																"%KICKERPREFIX%",
+																IRCd.getGroupPrefix(IRCd
+																		.getIRCUser(
+																				kickedByNick)
+																		.getTextModes()))
+														.replace(
+																"%KICKERSUFFIX%",
+																IRCd.getGroupSuffix(IRCd
+																		.getIRCUser(
+																				kickedByNick)
+																		.getTextModes())));
 							if ((BukkitIRCdPlugin.dynmap != null)
 									&& (msgIRCKickReasonDynmap.length() > 0))
 								BukkitIRCdPlugin.dynmap
@@ -1401,13 +1457,35 @@ public class IRCd implements Runnable {
 							println(":" + sourceUID + " KICK " + channelName
 									+ " " + uid + " :" + kickedByNick);
 							if (msgIRCKick.length() > 0)
-								BukkitIRCdPlugin.thePlugin.getServer()
+								BukkitIRCdPlugin.thePlugin
+										.getServer()
 										.broadcastMessage(
-												msgIRCKick.replace(
-														"%KICKEDUSER%",
-														iuser.nick).replace(
-														"%KICKEDBY%",
-														kickedByNick));
+												msgIRCKick
+														.replace(
+																"%KICKEDUSER%",
+																iuser.nick)
+														.replace("%KICKEDBY%",
+																kickedByNick)
+														.replace(
+																"%KICKEDPREFIX%",
+																IRCd.getGroupPrefix(iuser
+																		.getTextModes()))
+														.replace(
+																"%KICKEDSUFFIX%",
+																IRCd.getGroupSuffix(iuser
+																		.getTextModes()))
+														.replace(
+																"%KICKERPREFIX%",
+																IRCd.getGroupPrefix(IRCd
+																		.getIRCUser(
+																				kickedByNick)
+																		.getTextModes()))
+														.replace(
+																"%KICKERSUFFIX%",
+																IRCd.getGroupSuffix(IRCd
+																		.getIRCUser(
+																				kickedByNick)
+																		.getTextModes())));
 							if ((BukkitIRCdPlugin.dynmap != null)
 									&& (msgIRCKickDynmap.length() > 0))
 								BukkitIRCdPlugin.dynmap.sendBroadcastToWeb(
@@ -1715,7 +1793,7 @@ public class IRCd implements Runnable {
 				}
 				if (!mode1.equals("+")) {
 					if (mode == Modes.STANDALONE) {
-						
+
 						writeAll(":" + serverName + "!" + serverName + "@"
 								+ serverHostName + " MODE " + IRCd.channelName
 								+ " " + mode1 + " "
@@ -1849,7 +1927,7 @@ public class IRCd implements Runnable {
 							}
 							modestr = modestr
 									.substring(0, modestr.length() - 1);
-							
+
 							println(":" + serverUID + " FMODE " + channelName
 									+ " " + channelTS + " +" + textMode + " "
 									+ modestr);
@@ -2563,11 +2641,12 @@ public class IRCd implements Runnable {
 		// Goes from highest rank to lowest rank
 		String prefix;
 		// Owner
-		
-		if(IRCd.groupPrefixes == null){
+
+		if (IRCd.groupPrefixes == null) {
 			return "";
 		}
-		if (IRCd.groupPrefixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
+		if (IRCd.groupPrefixes.contains("q")
+				&& (modes.contains("q") || modes.contains("~"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("q");
 			} catch (NullPointerException e) {
@@ -2581,7 +2660,8 @@ public class IRCd implements Runnable {
 		// replace("@", "o").replace("%", "h").replace("+", "v");
 
 		// Super Op
-		if (IRCd.groupPrefixes.contains("a") && (modes.contains("a") || modes.contains("&"))) {
+		if (IRCd.groupPrefixes.contains("a")
+				&& (modes.contains("a") || modes.contains("&"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("a");
 			} catch (NullPointerException e) {
@@ -2593,7 +2673,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Op
-		if (IRCd.groupPrefixes.contains("o") && (modes.contains("o") || modes.contains("@"))) {
+		if (IRCd.groupPrefixes.contains("o")
+				&& (modes.contains("o") || modes.contains("@"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("o");
 			} catch (NullPointerException e) {
@@ -2605,7 +2686,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Half Op
-		if (IRCd.groupPrefixes.contains("h") && (modes.contains("h") || modes.contains("%"))) {
+		if (IRCd.groupPrefixes.contains("h")
+				&& (modes.contains("h") || modes.contains("%"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("h");
 			} catch (NullPointerException e) {
@@ -2617,7 +2699,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Voice
-		if (IRCd.groupPrefixes.contains("q") && (modes.contains("v") || modes.contains("+"))) {
+		if (IRCd.groupPrefixes.contains("q")
+				&& (modes.contains("v") || modes.contains("+"))) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("v");
 			} catch (NullPointerException e) {
@@ -2627,9 +2710,9 @@ public class IRCd implements Runnable {
 				return ChatColor.translateAlternateColorCodes('&', prefix);
 			}
 		}
-		
+
 		// User
-		if (IRCd.groupPrefixes.contains("user")){
+		if (IRCd.groupPrefixes.contains("user")) {
 			try {
 				prefix = IRCd.groupPrefixes.getString("user");
 			} catch (NullPointerException e) {
@@ -2638,10 +2721,10 @@ public class IRCd implements Runnable {
 			if (!prefix.isEmpty() || prefix != null) {
 				return ChatColor.translateAlternateColorCodes('&', prefix);
 			}
-			
+
 		}
-			return "";
-		
+		return "";
+
 	}
 
 	/**
@@ -2653,12 +2736,13 @@ public class IRCd implements Runnable {
 	public static String getGroupSuffix(String modes) {
 		// Goes from highest rank to lowest rank
 		String suffix;
-		
-		if (IRCd.groupSuffixes == null){
+
+		if (IRCd.groupSuffixes == null) {
 			return "";
 		}
 		// Owner
-		if (IRCd.groupSuffixes.contains("q") && (modes.contains("q") || modes.contains("~"))) {
+		if (IRCd.groupSuffixes.contains("q")
+				&& (modes.contains("q") || modes.contains("~"))) {
 			try {
 				suffix = IRCd.groupSuffixes.getString("q");
 			} catch (NullPointerException e) {
@@ -2672,7 +2756,8 @@ public class IRCd implements Runnable {
 		// replace("@", "o").replace("%", "h").replace("+", "v");
 
 		// Super Op
-		if (IRCd.groupSuffixes.contains("a") &&  (modes.contains("a") || modes.contains("&"))) {
+		if (IRCd.groupSuffixes.contains("a")
+				&& (modes.contains("a") || modes.contains("&"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("a");
 			} catch (NullPointerException e) {
@@ -2684,7 +2769,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Op
-		if (IRCd.groupSuffixes.contains("o") &&  (modes.contains("o") || modes.contains("@"))) {
+		if (IRCd.groupSuffixes.contains("o")
+				&& (modes.contains("o") || modes.contains("@"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("o");
 			} catch (NullPointerException e) {
@@ -2696,7 +2782,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Half Op
-		if (IRCd.groupSuffixes.contains("h") &&  (modes.contains("h") || modes.contains("%"))) {
+		if (IRCd.groupSuffixes.contains("h")
+				&& (modes.contains("h") || modes.contains("%"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("h");
 			} catch (NullPointerException e) {
@@ -2708,7 +2795,8 @@ public class IRCd implements Runnable {
 		}
 
 		// Voice
-		if (IRCd.groupSuffixes.contains("v") && (modes.contains("v") || modes.contains("+"))) {
+		if (IRCd.groupSuffixes.contains("v")
+				&& (modes.contains("v") || modes.contains("+"))) {
 			try {
 				suffix = IRCd.groupPrefixes.getString("v");
 			} catch (NullPointerException e) {
@@ -2718,7 +2806,7 @@ public class IRCd implements Runnable {
 				return ChatColor.translateAlternateColorCodes('&', suffix);
 			}
 		}
-		
+
 		// User
 		if (IRCd.groupSuffixes.contains("user")) {
 			try {
@@ -2731,7 +2819,7 @@ public class IRCd implements Runnable {
 			}
 		}
 		return "";
-		
+
 	}
 
 	// This is where the channel topic is configured
@@ -3676,8 +3764,12 @@ public class IRCd implements Runnable {
 							|| ((server = servers.get(split[0])) != null)) {
 						if (ircuser != null)
 							kicker = ircuser.nick;
+
 						else
 							kicker = server.host;
+						String modes = "q";
+						if (ircuser != null)
+							modes = ircuser.getTextModes();
 						if ((ircvictim = uid2ircuser.get(split[3])) != null) {
 							kicked = ircvictim.nick;
 							if ((IRCd.isPlugin)
@@ -3698,7 +3790,21 @@ public class IRCd implements Runnable {
 																		"%REASON%",
 																		convertColors(
 																				reason,
-																				true)));
+																				true))
+																.replace(
+																		"%KICKEDPREFIX%",
+																		IRCd.getGroupPrefix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKEDSUFFIX%",
+																		IRCd.getGroupSuffix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKERPREFIX%",
+																		IRCd.getGroupPrefix(modes))
+																.replace(
+																		"%KICKERSUFFIX%",
+																		IRCd.getGroupSuffix(modes)));
 									if ((BukkitIRCdPlugin.dynmap != null)
 											&& (msgIRCKickReasonDynmap.length() > 0))
 										BukkitIRCdPlugin.dynmap
@@ -3713,7 +3819,21 @@ public class IRCd implements Runnable {
 																		kicker)
 																.replace(
 																		"%REASON%",
-																		stripIRCFormatting(reason)));
+																		stripIRCFormatting(reason))
+																.replace(
+																		"%KICKEDPREFIX%",
+																		IRCd.getGroupPrefix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKEDSUFFIX%",
+																		IRCd.getGroupSuffix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKERPREFIX%",
+																		IRCd.getGroupPrefix(modes))
+																.replace(
+																		"%KICKERSUFFIX%",
+																		IRCd.getGroupSuffix(modes)));
 								} else {
 									if (msgIRCKick.length() > 0)
 										BukkitIRCdPlugin.thePlugin
@@ -3725,7 +3845,21 @@ public class IRCd implements Runnable {
 																		kicked)
 																.replace(
 																		"%KICKEDBY%",
-																		kicker));
+																		kicker)
+																.replace(
+																		"%KICKEDPREFIX%",
+																		IRCd.getGroupPrefix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKEDSUFFIX%",
+																		IRCd.getGroupSuffix(ircvictim
+																				.getTextModes()))
+																.replace(
+																		"%KICKERPREFIX%",
+																		IRCd.getGroupPrefix(modes))
+																.replace(
+																		"%KICKERSUFFIX%",
+																		IRCd.getGroupSuffix(modes)));
 									if ((BukkitIRCdPlugin.dynmap != null)
 											&& (msgIRCKickDynmap.length() > 0))
 										BukkitIRCdPlugin.dynmap

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
@@ -12,80 +12,219 @@ import com.Jdbye.BukkitIRCd.IRCUser;
 import com.Jdbye.BukkitIRCd.IRCd;
 import com.Jdbye.BukkitIRCd.Modes;
 
-public class IRCMsgCommand implements CommandExecutor{
+public class IRCMsgCommand implements CommandExecutor {
 
 	private BukkitIRCdPlugin thePlugin;
 
 	public IRCMsgCommand(BukkitIRCdPlugin plugin) {
 		this.thePlugin = plugin;
 	}
+
 	public boolean onCommand(CommandSender sender, Command cmd, String label,
 			String[] args) {
-		if (sender instanceof Player){
+		if (sender instanceof Player) {
 			Player player = (Player) sender;
 			if (player.hasPermission("bukkitircd.msg")) {
 				if (args.length > 1) {
 					IRCUser ircuser = IRCd.getIRCUser(args[0]);
 					if (ircuser != null) {
-						if (IRCd.mode == Modes.STANDALONE) { 
-							IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
-							player.sendMessage(ChatColor.RED + "Message sent.");
-						}
-						else if (IRCd.mode == Modes.INSPIRCD) {
+						if (IRCd.mode == Modes.STANDALONE) {
+							IRCd.writeTo(
+									ircuser.nick,
+									":"
+											+ player.getName()
+											+ IRCd.ingameSuffix
+											+ "!"
+											+ player.getName()
+											+ "@"
+											+ player.getAddress().getAddress()
+													.getHostName()
+											+ " PRIVMSG "
+											+ ircuser.nick
+											+ " :"
+											+ IRCd.convertColors(
+													IRCd.join(args, " ", 1),
+													false));
+							player.sendMessage(IRCd.msgSendQueryFromIngame
+									.replace(
+											"%PREFIX%",
+											IRCd.getGroupPrefix(ircuser
+													.getTextModes()))
+									.replace(
+											"%SUFFIX%",
+											IRCd.getGroupSuffix(ircuser
+													.getTextModes()))
+									.replace("%USER%", ircuser.nick)
+									.replace(
+											"%MESSAGE%",
+											IRCd.convertColors(
+													IRCd.join(args, " ", 0),
+													false)));
+							;
+
+						} else if (IRCd.mode == Modes.INSPIRCD) {
 							BukkitPlayer bp;
-							if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
+							if ((bp = IRCd
+									.getBukkitUserObject(player.getName())) != null) {
 								String UID = IRCd.getUIDFromIRCUser(ircuser);
 								if (UID != null) {
 									if (IRCd.linkcompleted) {
-										IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
-										player.sendMessage(ChatColor.RED + "Message sent.");
-									}
-									else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
+										IRCd.println(":"
+												+ bp.getUID()
+												+ " PRIVMSG "
+												+ UID
+												+ " :"
+												+ IRCd.convertColors(
+														IRCd.join(args, " ", 1),
+														false));
+										player.sendMessage(IRCd.msgSendQueryFromIngame
+												.replace(
+														"%PREFIX%",
+														IRCd.getGroupPrefix(ircuser
+																.getTextModes()))
+												.replace(
+														"%SUFFIX%",
+														IRCd.getGroupSuffix(ircuser
+																.getTextModes()))
+												.replace("%USER%", ircuser.nick)
+												.replace(
+														"%MESSAGE%",
+														IRCd.convertColors(
+																IRCd.join(args,
+																		" ", 0),
+																false)));
+										;
+									} else
+										player.sendMessage(ChatColor.RED
+												+ "Failed to send message, not currently linked to IRC server.");
+								} else {
+									BukkitIRCdPlugin.log
+											.severe("UID not found in list: "
+													+ UID); // Log this as
+															// severe since it
+															// should never
+															// occur unless
+															// something is
+															// wrong with the
+															// code
+									player.sendMessage(ChatColor.RED
+											+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
 								}
-								else {
-									BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-									player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-								}
-							}
-							else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
+							} else
+								player.sendMessage(ChatColor.RED
+										+ "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
 						}
+					} else {
+						player.sendMessage(ChatColor.RED
+								+ "That user is not online.");
 					}
-					else { player.sendMessage(ChatColor.RED + "That user is not online."); }
+				} else {
+					player.sendMessage(ChatColor.RED
+							+ "Please provide a nickname and a message.");
+					return false;
 				}
-				else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
+			} else {
+				player.sendMessage(ChatColor.RED
+						+ "You don't have access to that command.");
 			}
-			else {
-				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-			}    		
 			return true;
-		}else{
+		} else {
 			if (args.length > 1) {
 				IRCUser ircuser = IRCd.getIRCUser(args[0]);
 				if (ircuser != null) {
 					if (IRCd.mode == Modes.STANDALONE) {
-						IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 1),false));
-						sender.sendMessage(ChatColor.RED + "Message sent.");
-					}
-					else if (IRCd.mode == Modes.INSPIRCD) {
+						IRCd.writeTo(
+								ircuser.nick,
+								":"
+										+ IRCd.serverName
+										+ "!"
+										+ IRCd.serverName
+										+ "@"
+										+ IRCd.serverHostName
+										+ " PRIVMSG "
+										+ ircuser.nick
+										+ " :"
+										+ IRCd.convertColors(
+												IRCd.join(args, " ", 1), false));
+						sender.sendMessage(IRCd.msgSendQueryFromIngame
+								.replace(
+										"%PREFIX%",
+										IRCd.getGroupPrefix(ircuser
+												.getTextModes()))
+								.replace(
+										"%SUFFIX%",
+										IRCd.getGroupSuffix(ircuser
+												.getTextModes()))
+								.replace("%USER%", ircuser.nick)
+								.replace(
+										"%MESSAGE%",
+										IRCd.convertColors(
+												IRCd.join(args, " ", 0), false)));
+						;
+					} else if (IRCd.mode == Modes.INSPIRCD) {
 						String UID = IRCd.getUIDFromIRCUser(ircuser);
 						if (UID != null) {
 							if (IRCd.linkcompleted) {
-								IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 1), false));
-								sender.sendMessage(ChatColor.RED + "Message sent.");
-							} else sender.sendMessage(ChatColor.DARK_RED + "Failed to send message, not currently linked to IRC server.");
-						}
-						else {
-							BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-							sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+								IRCd.println(":"
+										+ IRCd.serverUID
+										+ " PRIVMSG "
+										+ UID
+										+ " :"
+										+ IRCd.convertColors(
+												IRCd.join(args, " ", 1), false));
+								sender.sendMessage(IRCd.msgSendQueryFromIngame
+										.replace(
+												"%PREFIX%",
+												IRCd.getGroupPrefix(ircuser
+														.getTextModes()))
+										.replace(
+												"%SUFFIX%",
+												IRCd.getGroupSuffix(ircuser
+														.getTextModes()))
+										.replace("%USER%", ircuser.nick)
+										.replace(
+												"%MESSAGE%",
+												IRCd.convertColors(
+														IRCd.join(args, " ", 0),
+														false)));
+								;
+							} else
+								sender.sendMessage(ChatColor.DARK_RED
+										+ "Failed to send message, not currently linked to IRC server.");
+						} else {
+							BukkitIRCdPlugin.log
+									.severe("UID not found in list: " + UID); // Log
+																				// this
+																				// as
+																				// severe
+																				// since
+																				// it
+																				// should
+																				// never
+																				// occur
+																				// unless
+																				// something
+																				// is
+																				// wrong
+																				// with
+																				// the
+																				// code
+							sender.sendMessage(ChatColor.RED
+									+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
 						}
 					}
+				} else {
+					sender.sendMessage(ChatColor.RED
+							+ "That user is not online.");
 				}
-				else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
+			} else {
+				sender.sendMessage(ChatColor.RED
+						+ "Please provide a nickname and a message.");
+				return false;
 			}
-			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
 			return true;
 		}
-		
+
 	}
 
 }

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
@@ -12,88 +12,239 @@ import com.Jdbye.BukkitIRCd.IRCUser;
 import com.Jdbye.BukkitIRCd.IRCd;
 import com.Jdbye.BukkitIRCd.Modes;
 
-public class IRCReplyCommand implements CommandExecutor{
+public class IRCReplyCommand implements CommandExecutor {
 
 	private BukkitIRCdPlugin thePlugin;
 
 	public IRCReplyCommand(BukkitIRCdPlugin plugin) {
 		this.thePlugin = plugin;
 	}
+
 	public boolean onCommand(CommandSender sender, Command cmd, String label,
 			String[] args) {
-		if (sender instanceof Player){
+		if (sender instanceof Player) {
 			Player player = (Player) sender;
 			if (player.hasPermission("bukkitircd.reply")) {
 				if (args.length > 0) {
-					String lastReceivedFrom = thePlugin.lastReceived.get(player.getName());
+					String lastReceivedFrom = thePlugin.lastReceived.get(player
+							.getName());
 					if (lastReceivedFrom == null) {
-						player.sendMessage(ChatColor.RED + "There are no messages to reply to!");
-					}
-					else {
+						player.sendMessage(ChatColor.RED
+								+ "There are no messages to reply to!");
+					} else {
 						IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
 						if (ircuser != null) {
 							if (IRCd.mode == Modes.STANDALONE) {
-								IRCd.writeTo(ircuser.nick, ":" + player.getName() + IRCd.ingameSuffix + "!" + player.getName() + "@" + player.getAddress().getAddress().getHostName() + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
-								player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-							}
-							else if (IRCd.mode == Modes.INSPIRCD) {
+								IRCd.writeTo(
+										ircuser.nick,
+										":"
+												+ player.getName()
+												+ IRCd.ingameSuffix
+												+ "!"
+												+ player.getName()
+												+ "@"
+												+ player.getAddress()
+														.getAddress()
+														.getHostName()
+												+ " PRIVMSG "
+												+ ircuser.nick
+												+ " :"
+												+ IRCd.convertColors(
+														IRCd.join(args, " ", 0),
+														false));
+								player.sendMessage(IRCd.msgSendQueryFromIngame
+										.replace(
+												"%PREFIX%",
+												IRCd.getGroupPrefix(ircuser
+														.getTextModes()))
+										.replace(
+												"%SUFFIX%",
+												IRCd.getGroupSuffix(ircuser
+														.getTextModes()))
+										.replace("%USER%", ircuser.nick)
+										.replace(
+												"%MESSAGE%",
+												IRCd.convertColors(
+														IRCd.join(args, " ", 0),
+														false)));
+							} else if (IRCd.mode == Modes.INSPIRCD) {
 								BukkitPlayer bp;
-								if ((bp = IRCd.getBukkitUserObject(player.getName())) != null) {
-									String UID = IRCd.getUIDFromIRCUser(ircuser);
+								if ((bp = IRCd.getBukkitUserObject(player
+										.getName())) != null) {
+									String UID = IRCd
+											.getUIDFromIRCUser(ircuser);
 									if (UID != null) {
 										if (IRCd.linkcompleted) {
-											IRCd.println(":" + bp.getUID() + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
-											player.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-										} else player.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
+											IRCd.println(":"
+													+ bp.getUID()
+													+ " PRIVMSG "
+													+ UID
+													+ " :"
+													+ IRCd.convertColors(
+															IRCd.join(args,
+																	" ", 0),
+															false));
+											player.sendMessage(IRCd.msgSendQueryFromIngame
+													.replace(
+															"%PREFIX%",
+															IRCd.getGroupPrefix(ircuser
+																	.getTextModes()))
+													.replace(
+															"%SUFFIX%",
+															IRCd.getGroupSuffix(ircuser
+																	.getTextModes()))
+													.replace("%USER%",
+															ircuser.nick)
+													.replace(
+															"%MESSAGE%",
+															IRCd.convertColors(
+																	IRCd.join(
+																			args,
+																			" ",
+																			0),
+																	false)));
+											;
+										} else
+											player.sendMessage(ChatColor.RED
+													+ "Failed to send message, not currently linked to IRC server.");
+									} else {
+										BukkitIRCdPlugin.log
+												.severe("UID not found in list: "
+														+ UID); // Log this as
+																// severe since
+																// it should
+																// never occur
+																// unless
+																// something is
+																// wrong with
+																// the code
+										player.sendMessage(ChatColor.RED
+												+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
 									}
-									else {
-										BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-										player.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-									}
-								}
-								else player.sendMessage(ChatColor.RED + "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
+								} else
+									player.sendMessage(ChatColor.RED
+											+ "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
 							}
+						} else {
+							player.sendMessage(ChatColor.RED
+									+ "That user is not online.");
 						}
-						else { player.sendMessage(ChatColor.RED + "That user is not online."); }
 					}
+				} else {
+					player.sendMessage(ChatColor.RED
+							+ "Please provide a nickname and a message.");
+					return false;
 				}
-				else { player.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }
+			} else {
+				player.sendMessage(ChatColor.RED
+						+ "You don't have access to that command.");
 			}
-			else {
-				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-			}    			
 			return true;
-		}else{
+		} else {
 			if (args.length > 0) {
-				String lastReceivedFrom = thePlugin.lastReceived.get("@CONSOLE@");
+				String lastReceivedFrom = thePlugin.lastReceived
+						.get("@CONSOLE@");
 				if (lastReceivedFrom == null) {
-					sender.sendMessage(ChatColor.RED + "There are no messages to reply to!");
-				}
-				else {
+					sender.sendMessage(ChatColor.RED
+							+ "There are no messages to reply to!");
+				} else {
 					IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
 					if (ircuser != null) {
 						if (IRCd.mode == Modes.STANDALONE) {
-							IRCd.writeTo(ircuser.nick, ":" + IRCd.serverName + "!" + IRCd.serverName + "@" + IRCd.serverHostName + " PRIVMSG " + ircuser.nick + " :" + IRCd.convertColors(IRCd.join(args, " ", 0),false));
-							sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-						}
-						else if (IRCd.mode == Modes.INSPIRCD) {
+							IRCd.writeTo(
+									ircuser.nick,
+									":"
+											+ IRCd.serverName
+											+ "!"
+											+ IRCd.serverName
+											+ "@"
+											+ IRCd.serverHostName
+											+ " PRIVMSG "
+											+ ircuser.nick
+											+ " :"
+											+ IRCd.convertColors(
+													IRCd.join(args, " ", 0),
+													false));
+							sender.sendMessage(IRCd.msgSendQueryFromIngame
+									.replace(
+											"%PREFIX%",
+											IRCd.getGroupPrefix(ircuser
+													.getTextModes()))
+									.replace(
+											"%SUFFIX%",
+											IRCd.getGroupSuffix(ircuser
+													.getTextModes()))
+									.replace("%USER%", ircuser.nick)
+									.replace(
+											"%MESSAGE%",
+											IRCd.convertColors(
+													IRCd.join(args, " ", 0),
+													false)));
+							;
+						} else if (IRCd.mode == Modes.INSPIRCD) {
 							String UID = IRCd.getUIDFromIRCUser(ircuser);
 							if (UID != null) {
 								if (IRCd.linkcompleted) {
-									IRCd.println(":" + IRCd.serverUID + " PRIVMSG " + UID + " :" + IRCd.convertColors(IRCd.join(args, " ", 0), false));
-									sender.sendMessage(ChatColor.RED + "Message sent to " + lastReceivedFrom + ".");
-								} else sender.sendMessage(ChatColor.RED + "Failed to send message, not currently linked to IRC server.");
-							}
-							else {
-								BukkitIRCdPlugin.log.severe("UID not found in list: " + UID); // Log this as severe since it should never occur unless something is wrong with the code
-								sender.sendMessage(ChatColor.RED + "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
+									IRCd.println(":"
+											+ IRCd.serverUID
+											+ " PRIVMSG "
+											+ UID
+											+ " :"
+											+ IRCd.convertColors(
+													IRCd.join(args, " ", 0),
+													false));
+									sender.sendMessage(IRCd.msgSendQueryFromIngame
+											.replace(
+													"%PREFIX%",
+													IRCd.getGroupPrefix(ircuser
+															.getTextModes()))
+											.replace(
+													"%SUFFIX%",
+													IRCd.getGroupSuffix(ircuser
+															.getTextModes()))
+											.replace("%USER%", ircuser.nick)
+											.replace(
+													"%MESSAGE%",
+													IRCd.convertColors(
+															IRCd.join(args,
+																	" ", 0),
+															false)));
+									;
+								} else
+									sender.sendMessage(ChatColor.RED
+											+ "Failed to send message, not currently linked to IRC server.");
+							} else {
+								BukkitIRCdPlugin.log
+										.severe("UID not found in list: " + UID); // Log
+																					// this
+																					// as
+																					// severe
+																					// since
+																					// it
+																					// should
+																					// never
+																					// occur
+																					// unless
+																					// something
+																					// is
+																					// wrong
+																					// with
+																					// the
+																					// code
+								sender.sendMessage(ChatColor.RED
+										+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
 							}
 						}
+					} else {
+						sender.sendMessage(ChatColor.RED
+								+ "That user is not online.");
 					}
-					else { sender.sendMessage(ChatColor.RED + "That user is not online."); }
 				}
+			} else {
+				sender.sendMessage(ChatColor.RED
+						+ "Please provide a nickname and a message.");
+				return false;
 			}
-			else { sender.sendMessage(ChatColor.RED + "Please provide a nickname and a message."); return false; }		
 			return true;
 		}
 	}


### PR DESCRIPTION
By default, shows `[IRC] [me -> {recv}] {message}`, mimicking Essentials's behaviour.
