### PR TITLE
Changed Java bytecode version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
The maven compiler plugin was set to Java bytecode 1.5 which is pretty outdated. I changed it to 1.6 which is pretty much standard on all systems nowadays.
