### PR TITLE
Fix redundant-modes and /imsg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.5.1-R0.2</version>
+            <version>1.5.2-R1.0</version>
         </dependency>
         <dependency>
 		<groupId>org.dynmap</groupId>

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlayerListener.java
@@ -133,7 +133,7 @@ public class BukkitIRCdPlayerListener implements Listener {
             	}
             	mode.append("+");
             }
-            if (!IRCd.redundantModes){
+            if (!IRCd.redundantModes && mode.length() > 0){
             	mode.delete(1, mode.length()); //Remove all but the mode powerful mode if redundant modes are not allowed
             }
             IRCd.addBukkitUser(mode.toString(),player);

--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -99,9 +99,13 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public static int link_delay = 60;
 	public static int link_serverid = new Random().nextInt(900) + 100;
 
+	public static boolean use_host_mask = false;
+	public static String mask_prefix = "BukkitIRCd-";
+	public static String mask_key = "0x00000000";
+
 	public static List<String> kickCommands = Arrays.asList("/kick");
 	public static final Logger log = Logger.getLogger("Minecraft");
-	
+
 	public boolean enableRawSend = false;
 
 //	public static PermissionHandler permissionHandler = null;
@@ -271,9 +275,13 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		IRCd.linkDelay = link_delay;
 		IRCd.SID = link_serverid;
 
+		IRCd.useHostMask = use_host_mask;
+		IRCd.maskKey = mask_key;
+		IRCd.maskPrefix = mask_prefix;
+
 		loadBans();
 		IRCd.bukkitPlayers.clear();
-		
+
 		// Set players to different IRC modes based on permission
 		for (Player player : getServer().getOnlinePlayers()) {
 			StringBuffer mode = new StringBuffer();
@@ -404,12 +412,16 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			link_delay = config.getInt("inspircd.connect-delay", link_delay);
 			link_serverid = config.getInt("inspircd.server-id", link_serverid);
 
+			use_host_mask = config.getBoolean("use-host-mask", use_host_mask);
+			mask_prefix = config.getString("host-mask-prefix", mask_prefix);
+			mask_key = config.getString("host-mask-key", mask_key);
+
 			if (operpass.length() == 0) ircd_operpass = "";
 			else if (operpass.startsWith("~")) { ircd_operpass = operpass.substring(1); }
 			else { ircd_operpass = Hash.compute(operpass, HashType.SHA_512); }
 
 			log.info("[BukkitIRCd] Loaded configuration file." + (IRCd.debugMode ? " Code BukkitIRCdPlugin363." : ""));
-			
+
 			saveConfig();
 			log.info("[BukkitIRCd] Saved initial configuration file." + (IRCd.debugMode ? " Code BukkitIRCdPlugin365." : ""));
 		}
@@ -418,7 +430,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		}
 	}
 
-	
+
 	/**
      * Converts color codes to processed codes
      *

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
@@ -58,7 +58,7 @@ public class IRCMsgCommand implements CommandExecutor {
 									.replace(
 											"%MESSAGE%",
 											IRCd.convertColors(
-													IRCd.join(args, " ", 0),
+													IRCd.join(args, " ", 1),
 													false)));
 							;
 
@@ -91,7 +91,7 @@ public class IRCMsgCommand implements CommandExecutor {
 														"%MESSAGE%",
 														IRCd.convertColors(
 																IRCd.join(args,
-																		" ", 0),
+																		" ", 1),
 																false)));
 										;
 									} else


### PR DESCRIPTION
Previously redundant-modes: false would cause an exception to be thrown if an unprivileged user joined. Additionally /imsg was including the username argument in the message when printing to the screen
