### PR TITLE
Avoid calling Bukkit API methods from IRCd thread

### DIFF
--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -33,16 +33,16 @@ import com.Jdbye.BukkitIRCd.commands.*;
  *
  * @author Jdbye
  */
- 
+
 public class BukkitIRCdPlugin extends JavaPlugin {
 	static class CriticalSection extends Object {
 	}
 	static public CriticalSection csLastReceived = new CriticalSection();
-	
+
 	private final BukkitIRCdPlayerListener playerListener = new BukkitIRCdPlayerListener(this);
 	private final BukkitIRCdServerListener serverListener = new BukkitIRCdServerListener(this);
 	private BukkitIRCdDynmapListener dynmapListener = null;
-	
+
 	private final HashMap<Player, Boolean> debugees = new HashMap<Player, Boolean>();
 
 	private String mode = "standalone";
@@ -86,7 +86,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public static boolean debugmode = false;
 	public boolean dynmapEventRegistered = false;
 	private boolean ircd_strip_ingame_suffix = true;
-	
+
 	public static String link_remotehost = "localhost";
 	public static int link_remoteport = 7000;
 	public static int link_localport = 7000;
@@ -120,12 +120,13 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		thePlugin = this;
 	}
 
+	@Override
 	public void onEnable() {
 		// Register our events
 		PluginManager pm = getServer().getPluginManager();
 		pm.registerEvents(this.playerListener, this);
 		pm.registerEvents(this.serverListener, this);
-		
+
 		PluginDescriptionFile pdfFile = getDescription();
 		ircd_version = pdfFile.getName() + " " + pdfFile.getVersion() + " by " + pdfFile.getAuthors().get(0);
 		setupMetrics();
@@ -142,16 +143,17 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		getCommand("irclink").setExecutor(new IRCLinkCommand(this));
 		getCommand("ircreload").setExecutor(new IRCReloadCommand(this));
 		getCommand("rawsend").setExecutor(new RawsendCommand(this));
-		
+
 		log.info(ircd_version + " is enabled!");
-		
+
 	}
-	
+
+	@Override
 	public void onDisable() {
 		if (ircd != null) {
 			ircd.running = false;
 			IRCd.disconnectAll();
-			ircd = null; 
+			ircd = null;
 		}
 		if (thr != null) {
 			thr.interrupt();
@@ -173,24 +175,24 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			return false;
 		}
 	}
-	
+
 	private void pluginInit() {
 		pluginInit(false);
 	}
-	
+
 	public void pluginInit(boolean reload) {
 		if (reload) {
 			if (ircd != null) {
 				ircd.running = false;
 				IRCd.disconnectAll("Reloading configuration.");
-				ircd = null; 
+				ircd = null;
 			}
 			if (thr != null) {
 				thr.interrupt();
 				thr = null;
 			}
 		}
-		
+
 		reloadConfig();
 		config = getConfig();
 		// Create default config.yml if it doesn't exist.
@@ -199,7 +201,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		}
 		config.options().copyDefaults(true);
 		loadSettings();
-		
+
 		// Create default messages.yml if it doesn't exist.
 		File messagesFile = new File(getDataFolder(), "messages.yml");
 		messages = YamlConfiguration.loadConfiguration(messagesFile);
@@ -208,10 +210,10 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			messages.options().copyDefaults(true);
 			saveDefaultMessages(getDataFolder(),"messages.yml");
 			log.info("[BukkitIRCd] Saving initial messages file." + (IRCd.debugMode ? " Code BukkitIRCdPlugin194." : ""));
-			
+
 		}
 		messages.options().copyDefaults(true);
-		
+
 
 		if (!(new File(getDataFolder(), "motd.txt")).exists()) {
 			saveDefaultMOTD(getDataFolder(),"motd.txt");
@@ -225,9 +227,9 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		}
 
 		setupDynmap();
-		
+
 		ircd = new IRCd();
-		
+
 		loadMessages(ircd);
 		IRCd.redundantModes = ircd_redundant_modes;
 		IRCd.port = ircd_port;
@@ -281,6 +283,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		IRCd.maskPrefix = mask_prefix;
 		IRCd.maskSuffix = mask_suffix;
 
+		IRCd.bukkitVersion = getServer().getVersion();
+
 		loadBans();
 		IRCd.bukkitPlayers.clear();
 
@@ -329,8 +333,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	public void setDebugging(final Player player, final boolean value) {
 		debugees.put(player, value);
 	}
-	
-	
+
+
 	// check for Dynmap, and if it's installed, register events and hooks
 	private void setupDynmap() {
 		PluginManager pm = getServer().getPluginManager();
@@ -338,14 +342,14 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		if (BukkitIRCdPlugin.dynmap == null) {
 			if (plugin != null) {
 				if (dynmapListener == null) dynmapListener = new BukkitIRCdDynmapListener(this);
-				if (!dynmapEventRegistered) { 
+				if (!dynmapEventRegistered) {
 					pm.registerEvents(this.dynmapListener, this);
 				}
 				setupDynmap((DynmapAPI)plugin);
 			}
 		}
 	}
-	
+
 	public void setupDynmap(DynmapAPI plugin) {
 		if (plugin != null) {
 			dynmap = plugin;
@@ -385,7 +389,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			kickCommands = config.getStringList("kick-commands");
 
 			String operpass = "";
-			
+
 			ircd_port = config.getInt("standalone.port", ircd_port);
 			ircd_maxconn = config.getInt("standalone.max-connections", ircd_maxconn);
 			ircd_pinginterval = config.getInt("standalone.ping-interval", ircd_pinginterval);
@@ -445,22 +449,22 @@ public class BukkitIRCdPlugin extends JavaPlugin {
         if (message == null) return null;
         return message.replaceAll("&([a-f0-9k-or])", "\u00a7$1");
     }
-	
+
 	// Load the messages from messages.yml
 	private void loadMessages(IRCd ircd) {
 		try {
 			IRCd.msgLinked = messages.getString("linked", IRCd.msgLinked);
-			
+
 			IRCd.msgSendQueryFromIngame = messages.getString("irc-send-pm", IRCd.msgSendQueryFromIngame);
 			IRCd.msgDelinked = messages.getString("delinked", IRCd.msgDelinked);
 			IRCd.msgDelinkedReason = messages.getString("delinked-reason", IRCd.msgDelinkedReason);
-			
+
 			IRCd.msgIRCJoin = messages.getString("irc-join", IRCd.msgIRCJoin);
 			IRCd.msgIRCJoinDynmap = messages.getString("irc-join-dynmap", IRCd.msgIRCJoinDynmap);
 
 			IRCd.groupPrefixes = messages.getConfigurationSection("group-prefixes");
 			IRCd.groupSuffixes = messages.getConfigurationSection("group-suffixes");
-			
+
 			IRCd.msgIRCLeave = messages.getString("irc-leave", IRCd.msgIRCLeave);
 			IRCd.msgIRCLeaveReason = messages.getString("irc-leave-reason", IRCd.msgIRCLeaveReason);
 			IRCd.msgIRCLeaveDynmap = messages.getString("irc-leave-dynmap", IRCd.msgIRCLeaveDynmap);
@@ -494,10 +498,10 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 
 			IRCd.msgDynmapMessage = messages.getString("dynmap-message", IRCd.msgDynmapMessage);
 			IRCd.msgPlayerList = messages.getString("player-list", IRCd.msgPlayerList);
-			
+
 			IRCd.consoleFilters = messages.getStringList("console-filters");
 			//** RECOLOUR ALL MESSAGES **
-			
+
 			IRCd.msgSendQueryFromIngame = colorize(IRCd.msgSendQueryFromIngame);
 			IRCd.msgLinked = colorize(IRCd.msgLinked);
 			IRCd.msgDelinked = colorize(IRCd.msgDelinked);
@@ -557,7 +561,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 
 		writeSettings(configFile);
 	}
-	
+
 	// Set up the MOTD for the standalone BukkitIRCd server
 	private void loadMOTD() {
 		File motdFile = new File(getDataFolder(), "motd.txt");
@@ -721,7 +725,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			bufferWriter.newLine();
 			bufferWriter.append("");
 			bufferWriter.newLine();
-			bufferWriter.append("_________        __    __   .__        ___________  _____     _"); 
+			bufferWriter.append("_________        __    __   .__        ___________  _____     _");
 			bufferWriter.newLine();
 			bufferWriter.append("\\______  \\___ __|  |  |  |  |__| __   |_   _| ___ \\/  __ \\   | |");
 			bufferWriter.newLine();
@@ -769,7 +773,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			}
 		}
 	}
-	
+
 	// Was also disabled, I'd like to know why
 	private void saveDefaultMessages(File dataFolder, String fileName)
 	{
@@ -789,8 +793,8 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 
 		writeMessages(msgFile);
 	}
-	
-	
+
+
 	private void writeMessages(File messagesFile)
 	{
 		try
@@ -848,7 +852,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 	{
 		List<String> update = new ArrayList<String>();
 		synchronized(csLastReceived) {
-			for (Map.Entry<String, String> lastReceivedEntry : lastReceived.entrySet()) { 
+			for (Map.Entry<String, String> lastReceivedEntry : lastReceived.entrySet()) {
 				if (lastReceivedEntry.getValue().equalsIgnoreCase(oldReceivedFrom)) update.add(lastReceivedEntry.getKey());
 			}
 			for (String toUpdate : update) lastReceived.put(toUpdate, newReceivedFrom);
@@ -880,7 +884,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 			fromIndex = text.indexOf(search, fromIndex + ((count > 0) ? 1 : 0));
 		return count - 1;
 	}
-	
+
 	public int[] convertStringArrayToIntArray(String[] sarray, int[] def) {
 		try {
 			if (sarray != null) {
@@ -893,7 +897,7 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		} catch (Exception e) { log.severe("[BukkitIRCd] Unable to parse string array " + IRCd.join(sarray, " ", 0) + ", invalid number. " + e); }
 		return def;
 	}
-	
+
 	/**
 	 * Setup PluginMetrics
 	 */

--- a/src/com/Jdbye/BukkitIRCd/BukkitKickRunnable.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitKickRunnable.java
@@ -1,26 +1,22 @@
 package com.Jdbye.BukkitIRCd;
 
-import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
 
 public class BukkitKickRunnable extends BukkitRunnable{
 
-
-	//We need this to avoid async kicks. 
+	//We need this to avoid async kicks.
 	//Kicks are not thread safe
-	private Player kickedPlayer;
-	private String kickReason;
-	public BukkitKickRunnable(BukkitIRCdPlugin instance, Player kickedPlayer, String kickReason){
+	private final String kickedPlayer;
+	private final String kickReason;
+	public BukkitKickRunnable(BukkitIRCdPlugin instance, String kickedPlayer, String kickReason){
 		this.kickedPlayer = kickedPlayer;
 		this.kickReason = kickReason;
-		
+
 	}
 
+	@Override
 	public void run() {
-		kickedPlayer.kickPlayer(kickReason);
+		Bukkit.getServer().getPlayer(kickedPlayer).kickPlayer(kickReason);
 	}
-	
-	
-	
-	
 }

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -84,6 +84,7 @@ import org.bukkit.Server;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.scheduler.BukkitRunnable;
 
 @SuppressWarnings("unused")
 public class IRCd implements Runnable {
@@ -462,8 +463,7 @@ public class IRCd implements Runnable {
 								if ((IRCd.isPlugin)
 										&& (BukkitIRCdPlugin.thePlugin != null)) {
 									if (msgLinked.length() > 0)
-										BukkitIRCdPlugin.thePlugin.getServer()
-												.broadcastMessage(
+										IRCd.broadcastMessage(
 														msgLinked.replace(
 																"%LINKNAME%",
 																linkName));
@@ -553,8 +553,7 @@ public class IRCd implements Runnable {
 									&& (BukkitIRCdPlugin.thePlugin != null)
 									&& linkcompleted) {
 								if (msgDelinked.length() > 0)
-									BukkitIRCdPlugin.thePlugin.getServer()
-											.broadcastMessage(
+									IRCd.broadcastMessage(
 													msgDelinked.replace(
 															"%LINKNAME%",
 															linkName));
@@ -1044,9 +1043,7 @@ public class IRCd implements Runnable {
 										.removeLastReceivedFrom(processor.nick);
 								if (reason != null) {
 									if (msgIRCLeave.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										IRCd.broadcastMessage(
 														msgIRCLeaveReason
 																.replace(
 																		"%USER%",
@@ -1076,9 +1073,7 @@ public class IRCd implements Runnable {
 																		stripIRCFormatting(reason)));
 								} else {
 									if (msgIRCLeave.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										broadcastMessage(
 														msgIRCLeave
 																.replace(
 																		"%USER%",
@@ -1124,9 +1119,7 @@ public class IRCd implements Runnable {
 							BukkitIRCdPlugin.thePlugin
 									.removeLastReceivedFrom(processor.nick);
 							if (msgIRCLeave.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeave
 														.replace("%USER%",
 																processor.nick)
@@ -1171,9 +1164,7 @@ public class IRCd implements Runnable {
 					if (curUser.joined) {
 
 						if (msgIRCLeaveReason.length() > 0)
-							BukkitIRCdPlugin.thePlugin
-									.getServer()
-									.broadcastMessage(
+							broadcastMessage(
 											msgIRCLeaveReason
 													.replace("%USER%",
 															curUser.nick)
@@ -1261,9 +1252,7 @@ public class IRCd implements Runnable {
 									&& (BukkitIRCdPlugin.thePlugin != null)) {
 								if (reason != null) {
 									if (msgIRCKickReason.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										broadcastMessage(
 														msgIRCKickReason
 																.replace(
 																		"%KICKEDUSER%",
@@ -1311,9 +1300,7 @@ public class IRCd implements Runnable {
 																		stripIRCFormatting(reason)));
 								} else {
 									if (msgIRCKick.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										broadcastMessage(
 														msgIRCKick
 																.replace(
 																		"%KICKEDUSER%",
@@ -1430,9 +1417,7 @@ public class IRCd implements Runnable {
 							println(":" + sourceUID + " KICK " + channelName
 									+ " " + uid + " :" + reason);
 							if (msgIRCKickReason.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCKickReason
 														.replace(
 																"%KICKEDUSER%",
@@ -1482,9 +1467,7 @@ public class IRCd implements Runnable {
 							println(":" + sourceUID + " KICK " + channelName
 									+ " " + uid + " :" + kickedByNick);
 							if (msgIRCKick.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCKick
 														.replace(
 																"%KICKEDUSER%",
@@ -1589,9 +1572,7 @@ public class IRCd implements Runnable {
 							if ((isPlugin)
 									&& (BukkitIRCdPlugin.thePlugin != null)) {
 								if (msgIRCBan.length() > 0)
-									BukkitIRCdPlugin.thePlugin
-											.getServer()
-											.broadcastMessage(
+									broadcastMessage(
 													msgIRCBan
 															.replace(
 																	"%BANNEDUSER%",
@@ -2091,6 +2072,23 @@ public class IRCd implements Runnable {
 		} else
 			return false;
 	}
+
+	public static boolean broadcastMessage(final String msg) {
+		try {
+			if (bukkitServer != null) {
+				new BukkitRunnable() {
+                                        public void run() {
+                                                bukkitServer.broadcastMessage(msg);
+                                        }}
+					.runTaskLater(BukkitIRCdPlugin.thePlugin, 1L);
+				return true;
+			} else
+				return false;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
 
 	/**
 	 * Kicks player synchronously
@@ -2963,9 +2961,7 @@ public class IRCd implements Runnable {
 					println(pre + "SQUIT " + SID + " :" + reason);
 					if (linkcompleted) {
 						if (msgDelinkedReason.length() > 0)
-							BukkitIRCdPlugin.thePlugin
-									.getServer()
-									.broadcastMessage(
+							broadcastMessage(
 											msgDelinkedReason
 													.replace("%LINKNAME%",
 															linkName)
@@ -3255,9 +3251,7 @@ public class IRCd implements Runnable {
 							if (!ircuser.joined) {
 
 								if (msgIRCJoin.length() > 0)
-									BukkitIRCdPlugin.thePlugin
-											.getServer()
-											.broadcastMessage(
+									broadcastMessage(
 													msgIRCJoin
 															.replace(
 																	"%USER%",
@@ -3426,9 +3420,7 @@ public class IRCd implements Runnable {
 								if ((ircuser = uid2ircuser.get(split[0])) != null) {
 									if (add) {
 										if (msgIRCBan.length() > 0)
-											BukkitIRCdPlugin.thePlugin
-													.getServer()
-													.broadcastMessage(
+											broadcastMessage(
 															msgIRCBan
 																	.replace(
 																			"%BANNEDUSER%",
@@ -3450,9 +3442,7 @@ public class IRCd implements Runnable {
 																			ircuser.nick));
 									} else {
 										if (msgIRCUnban.length() > 0)
-											BukkitIRCdPlugin.thePlugin
-													.getServer()
-													.broadcastMessage(
+											broadcastMessage(
 															msgIRCUnban
 																	.replace(
 																			"%BANNEDUSER%",
@@ -3602,9 +3592,7 @@ public class IRCd implements Runnable {
 				if ((IRCd.isPlugin) && (BukkitIRCdPlugin.thePlugin != null)
 						&& (ircuser.joined)) {
 					if (msgIRCNickChange.length() > 0)
-						BukkitIRCdPlugin.thePlugin
-								.getServer()
-								.broadcastMessage(
+						broadcastMessage(
 										msgIRCNickChange
 												.replace("%OLDNICK%",
 														ircuser.nick)
@@ -3730,9 +3718,7 @@ public class IRCd implements Runnable {
 									&& (BukkitIRCdPlugin.thePlugin != null)) {
 								if (reason != null) {
 									if (msgIRCKickReason.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										broadcastMessage(
 														msgIRCKickReason
 																.replace(
 																		"%KICKEDUSER%",
@@ -3790,9 +3776,7 @@ public class IRCd implements Runnable {
 																		IRCd.getGroupSuffix(modes)));
 								} else {
 									if (msgIRCKick.length() > 0)
-										BukkitIRCdPlugin.thePlugin
-												.getServer()
-												.broadcastMessage(
+										broadcastMessage(
 														msgIRCKick
 																.replace(
 																		"%KICKEDUSER%",
@@ -3885,9 +3869,7 @@ public class IRCd implements Runnable {
 						if (reason != null) {
 
 							if (msgIRCLeaveReason.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeaveReason
 														.replace("%USER%",
 																ircuser.nick)
@@ -3918,9 +3900,7 @@ public class IRCd implements Runnable {
 						} else {
 
 							if (msgIRCLeave.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeave
 														.replace("%USER%",
 																ircuser.nick)
@@ -3983,9 +3963,7 @@ public class IRCd implements Runnable {
 						if (reason != null) {
 
 							if (msgIRCLeaveReason.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeaveReason
 														.replace("%USER%",
 																ircuser.nick)
@@ -4016,9 +3994,7 @@ public class IRCd implements Runnable {
 						} else {
 
 							if (msgIRCLeave.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeave
 														.replace("%USER%",
 																ircuser.nick)
@@ -4135,9 +4111,7 @@ public class IRCd implements Runnable {
 						if (ircuser2.joined) {
 
 							if (msgIRCLeaveReason.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								broadcastMessage(
 												msgIRCLeaveReason
 														.replace("%USER%", user)
 														.replace(
@@ -4288,9 +4262,7 @@ public class IRCd implements Runnable {
 								msg = msg.replace(IRCd.ingameSuffix,"");
 							}
 
-									BukkitIRCdPlugin.thePlugin
-											.getServer()
-											.broadcastMessage(msg
+								broadcastMessage(msg
 													);}
 								if ((BukkitIRCdPlugin.dynmap != null)
 										&& (msgtemplatedynmap.length() > 0))
@@ -4613,9 +4585,7 @@ class ClientConnection implements Runnable {
 						if ((IRCd.isPlugin)
 								&& (BukkitIRCdPlugin.thePlugin != null)) {
 							if (IRCd.msgIRCNickChange.length() > 0)
-								BukkitIRCdPlugin.thePlugin
-										.getServer()
-										.broadcastMessage(
+								IRCd.broadcastMessage(
 												IRCd.msgIRCNickChange
 														.replace("%OLDNICK%",
 																nick)
@@ -4833,9 +4803,7 @@ class ClientConnection implements Runnable {
 												host = mask + "!*@*";
 											if (add == 1) {
 												if (IRCd.msgIRCBan.length() > 0)
-													BukkitIRCdPlugin.thePlugin
-															.getServer()
-															.broadcastMessage(
+													IRCd.broadcastMessage(
 																	IRCd.msgIRCBan
 																			.replace(
 																					"%BANNEDUSER%",
@@ -4860,9 +4828,7 @@ class ClientConnection implements Runnable {
 														getFullHost());
 											} else if (add == 0) {
 												if (IRCd.msgIRCUnban.length() > 0)
-													BukkitIRCdPlugin.thePlugin
-															.getServer()
-															.broadcastMessage(
+													IRCd.broadcastMessage(
 																	IRCd.msgIRCUnban
 																			.replace(
 																					"%BANNEDUSER%",
@@ -5004,7 +4970,7 @@ class ClientConnection implements Runnable {
 								if (p != null) {
 									if (reason != null) {
 										if (IRCd.msgIRCKickReason.length() > 0)
-											s.broadcastMessage(IRCd.msgIRCKickReason
+											IRCd.broadcastMessage(IRCd.msgIRCKickReason
 													.replace("%KICKEDUSER%",
 															bannick)
 													.replace("%KICKEDBY%", nick)
@@ -5021,7 +4987,7 @@ class ClientConnection implements Runnable {
 														+ IRCd.stripIRCFormatting(reason));
 									} else {
 										if (IRCd.msgIRCKick.length() > 0)
-											s.broadcastMessage(IRCd.msgIRCKick
+											IRCd.broadcastMessage(IRCd.msgIRCKick
 													.replace("%KICKEDUSER%",
 															bannick).replace(
 															"%KICKEDBY%", nick));
@@ -5236,9 +5202,7 @@ class ClientConnection implements Runnable {
 									if (isAction) {
 
 										if (IRCd.msgIRCAction.length() > 0)
-											BukkitIRCdPlugin.thePlugin
-													.getServer()
-													.broadcastMessage(
+											IRCd.broadcastMessage(
 															IRCd.msgIRCAction
 																	.replace(
 																			"%USER%",
@@ -5270,9 +5234,7 @@ class ClientConnection implements Runnable {
 									} else {
 
 										if (IRCd.msgIRCMessage.length() > 0)
-											BukkitIRCdPlugin.thePlugin
-													.getServer()
-													.broadcastMessage(
+											IRCd.broadcastMessage(
 															IRCd.msgIRCMessage
 																	.replace(
 																			"%USER%",
@@ -5475,9 +5437,7 @@ class ClientConnection implements Runnable {
 								&& (BukkitIRCdPlugin.thePlugin != null)) {
 							if ((!isCTCP) && IRCd.enableNotices) {
 								if (IRCd.msgIRCNotice.length() > 0)
-									BukkitIRCdPlugin.thePlugin
-											.getServer()
-											.broadcastMessage(
+									IRCd.broadcastMessage(
 													IRCd.msgIRCNotice
 															.replace("%USER%",
 																	nick)
@@ -5619,7 +5579,7 @@ class ClientConnection implements Runnable {
 			sendMOTD();
 			if ((IRCd.isPlugin) && (BukkitIRCdPlugin.thePlugin != null)) {
 				if (IRCd.msgIRCJoin.length() > 0)
-					BukkitIRCdPlugin.thePlugin.getServer().broadcastMessage(
+					IRCd.broadcastMessage(
 							IRCd.msgIRCJoin
 									.replace("%USER%", nick)
 									.replace("%SUFFIX%",


### PR DESCRIPTION
These calls are unsafe and raise exceptions when thread scheduling causes collections to change while IRCd is handling link messages.
