### PR TITLE
Cleanups

### DIFF
--- a/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
+++ b/src/com/Jdbye/BukkitIRCd/BukkitIRCdPlugin.java
@@ -97,10 +97,9 @@ public class BukkitIRCdPlugin extends JavaPlugin {
 		getCommand("irctopic").setExecutor(new IRCTopicCommand(this));
 		getCommand("irclink").setExecutor(new IRCLinkCommand(this));
 		getCommand("ircreload").setExecutor(new IRCReloadCommand(this));
-		getCommand("rawsend").setExecutor(new RawsendCommand(this));
+		getCommand("rawsend").setExecutor(new RawsendCommand());
 
 		log.info(ircdVersion + " is enabled!");
-
 	}
 
 	@Override

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -215,10 +215,7 @@ public class IRCd implements Runnable {
 				}
 
 				serverMessagePrefix = ":" + Config.getIrcdServerHostName();
-                if (Config.getMode().equalsIgnoreCase("unreal")
-						|| Config.getMode().equalsIgnoreCase("unrealircd"))
-					mode = Modes.UNREALIRCD;
-				else if (Config.getMode().equalsIgnoreCase("inspire")
+				if (Config.getMode().equalsIgnoreCase("inspire")
 						|| Config.getMode().equalsIgnoreCase("inspircd"))
 					mode = Modes.INSPIRCD;
 				else
@@ -2267,15 +2264,18 @@ public class IRCd implements Runnable {
 
 	public static void disconnectAll(String reason) {
 		synchronized (csIrcUsers) {
-			if (mode == Modes.STANDALONE) {
+			switch (mode) {
+			case STANDALONE:
 				try {
 					listener.close();
 					listener = null;
 				} catch (IOException e) {
 				}
 				removeIRCUsers();
-			} else if ((mode == Modes.INSPIRCD) || (mode == Modes.UNREALIRCD)) {
+				break;
+			case INSPIRCD:
 				disconnectServer(reason);
+				break;
 			}
 		}
 	}

--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -2945,6 +2945,27 @@ public class IRCd implements Runnable {
 		}
 	}
 
+	/**
+	 *
+	 * @param source UID of sender
+	 * @param target name of target
+	 * @param message message to send encoded with IRC colors
+	 */
+	public static void privmsg(final String source, final String target, final String message) {
+		IRCd.println(":" + source + " PRIVMSG " + target + " :" + message);
+	}
+
+	/**
+	 *
+	 * @param source UID of sender
+	 * @param target name of target
+	 * @param message message to send with IRC colors
+	 */
+	public static void action(final String source, final String target, final String message) {
+		final String action = (char)1 + "ACTION " + message + (char)1;
+		IRCd.privmsg(source, target, action);
+	}
+
 	public static void disconnectServer(String reason) {
 		if (reason == null)
 			reason = "Disabling Plugin";

--- a/src/com/Jdbye/BukkitIRCd/Modes.java
+++ b/src/com/Jdbye/BukkitIRCd/Modes.java
@@ -1,5 +1,5 @@
 package com.Jdbye.BukkitIRCd;
 
 public enum Modes {
-	STANDALONE, INSPIRCD, UNREALIRCD
+	STANDALONE, INSPIRCD
 }

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCLinkCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCLinkCommand.java
@@ -2,7 +2,6 @@ package com.Jdbye.BukkitIRCd.commands;
 
 import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
 import com.Jdbye.BukkitIRCd.IRCd;
-import com.Jdbye.BukkitIRCd.Modes;
 import com.Jdbye.BukkitIRCd.configuration.Config;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -14,42 +13,39 @@ public class IRCLinkCommand implements CommandExecutor{
 
 	public IRCLinkCommand(BukkitIRCdPlugin plugin) {
 	}
+	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label,
 			String[] args) {
-		if (sender instanceof Player){
-			Player player = (Player) sender;
-			if (player.hasPermission("bukkitircd.link")) {
-				if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-					if ((!IRCd.isLinkcompleted()) && (!IRCd.isConnected())) {
-						if (IRCd.connect()) player.sendMessage(ChatColor.RED + "Successfully connected to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
-						else player.sendMessage(ChatColor.RED + "Failed to connect to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
-					}
-					else {
-						if (IRCd.isLinkcompleted()) player.sendMessage(ChatColor.RED + "Already linked to " + Config.getLinkName() + ".");
-						else player.sendMessage(ChatColor.RED + "Already connected to " + Config.getLinkName() + ", but not linked.");
-					}
-				}
-				else { player.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
-			}
-			else {
-				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
-			}
-			return true;
-		}else{
-			
-			if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-				if ((!IRCd.isLinkcompleted()) && (!IRCd.isConnected())) {
-					if (IRCd.connect()) sender.sendMessage(ChatColor.RED + "Successfully connected to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
-					else sender.sendMessage(ChatColor.RED + "Failed to connect to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
-				}
-				else {
-					if (IRCd.isLinkcompleted()) sender.sendMessage(ChatColor.RED + "Already linked to " + Config.getLinkName() + ".");
-					else sender.sendMessage(ChatColor.RED + "Already connected to " + Config.getLinkName() + ", but not linked.");
-				}
-			}
-			else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config."); }
-			return true;
-		}
-	}
 
+		if (sender instanceof Player){
+			final Player player = (Player) sender;
+			if (!player.hasPermission("bukkitircd.link")) {
+				player.sendMessage(ChatColor.RED + "You don't have access to that command.");
+				return true;
+			}
+		}
+
+		switch (IRCd.mode) {
+		case INSPIRCD:
+			if ((!IRCd.isLinkcompleted()) && (!IRCd.isConnected())) {
+				if (IRCd.connect()) {
+					sender.sendMessage(ChatColor.RED + "Successfully connected to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
+				} else {
+					sender.sendMessage(ChatColor.RED + "Failed to connect to " + Config.getLinkRemoteHost() + " on port " + Config.getLinkRemotePort());
+				}
+			} else {
+				if (IRCd.isLinkcompleted()) {
+					sender.sendMessage(ChatColor.RED + "Already linked to " + Config.getLinkName() + ".");
+				} else {
+					sender.sendMessage(ChatColor.RED + "Already connected to " + Config.getLinkName() + ", but not linked.");
+				}
+			}
+			break;
+		case STANDALONE:
+			sender.sendMessage(ChatColor.RED + "[BukkitIRCd] You are currently in standalone mode. To link to a server, modify the config.");
+			break;
+		}
+
+		return true;
+	}
 }

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCMsgCommand.java
@@ -67,14 +67,8 @@ public class IRCMsgCommand implements CommandExecutor {
 								String UID = IRCd.getUIDFromIRCUser(ircuser);
 								if (UID != null) {
 									if (IRCd.isLinkcompleted()) {
-										IRCd.println(":"
-												+ bp.getUID()
-												+ " PRIVMSG "
-												+ UID
-												+ " :"
-												+ IRCd.convertColors(
-														IRCd.join(args, " ", 1),
-														false));
+										IRCd.privmsg(bp.getUID(), UID, IRCd.convertColors(IRCd.join(args, " ", 1), false));
+
 										player.sendMessage(IRCd.msgSendQueryFromIngame
 												.replace(
 														"{Prefix}",
@@ -85,9 +79,8 @@ public class IRCMsgCommand implements CommandExecutor {
 														IRCd.getGroupSuffix(ircuser
 																.getTextModes()))
 												.replace("{User}", ircuser.nick)
-												.replace(
-														"{Message}",
-														IRCd.convertColors(
+												.replace("{Message}",
+														 IRCd.convertColors(
 																IRCd.join(args,
 																		" ", 1),
 																false)));
@@ -163,13 +156,9 @@ public class IRCMsgCommand implements CommandExecutor {
 						String UID = IRCd.getUIDFromIRCUser(ircuser);
 						if (UID != null) {
 							if (IRCd.isLinkcompleted()) {
-								IRCd.println(":"
-										+ IRCd.serverUID
-										+ " PRIVMSG "
-										+ UID
-										+ " :"
-										+ IRCd.convertColors(
-												IRCd.join(args, " ", 1), false));
+								IRCd.privmsg(IRCd.serverUID, UID,
+										IRCd.convertColors(IRCd.join(args, " ", 1), false));
+
 								sender.sendMessage(IRCd.msgSendQueryFromIngame
 										.replace(
 												"{Prefix}",

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
@@ -4,7 +4,6 @@ import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
 import com.Jdbye.BukkitIRCd.BukkitPlayer;
 import com.Jdbye.BukkitIRCd.IRCUser;
 import com.Jdbye.BukkitIRCd.IRCd;
-import com.Jdbye.BukkitIRCd.Modes;
 import com.Jdbye.BukkitIRCd.configuration.Config;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -23,22 +22,57 @@ public class IRCReplyCommand implements CommandExecutor {
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label,
 			String[] args) {
-		if (sender instanceof Player) {
-			Player player = (Player) sender;
-			if (player.hasPermission("bukkitircd.reply")) {
-				if (args.length > 0) {
-					String lastReceivedFrom = thePlugin.lastReceived.get(player
-							.getName());
-					if (lastReceivedFrom == null) {
-						player.sendMessage(ChatColor.RED
-								+ "There are no messages to reply to!");
-					} else {
-						IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
-						if (ircuser != null) {
-							if (IRCd.mode == Modes.STANDALONE) {
-								IRCd.writeTo(
-										ircuser.nick,
-										":"
+
+		if (args.length < 1) {
+			return false; // Print usage message
+		}
+
+		final Player player = sender instanceof Player ? (Player)sender : null;
+
+		// Determine sender name
+		final String senderName;
+		if (player == null) {
+			senderName = "@CONSOLE@";
+		} else {
+			senderName = player.getName();
+		}
+
+		// Determine target name
+		final String lastReceivedFrom = thePlugin.lastReceived.get(senderName);
+
+		// Verify target
+		if (lastReceivedFrom == null) {
+			sender.sendMessage(ChatColor.RED + "There are no messages to reply to!");
+			return true;
+		}
+
+		// Lookup target's user object
+		final IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
+		if (ircuser == null) {
+			sender.sendMessage(ChatColor.RED + "Player offline");
+			return true;
+		}
+
+		// Attempt to send IRC message
+		switch (IRCd.mode) {
+		case STANDALONE:
+			if (player == null) {
+				IRCd.writeTo(
+							ircuser.nick,
+							":"
+									+ Config.getIrcdServerName()
+									+ "!"
+									+ Config.getIrcdServerName()
+									+ "@"
+									+ Config.getIrcdServerHostName()
+									+ " PRIVMSG "
+									+ ircuser.nick
+									+ " :"
+									+ IRCd.convertColors(
+											IRCd.join(args, " ", 0),
+											false));
+			} else {
+				IRCd.writeTo(ircuser.nick, ":"
 												+ player.getName()
 												+ Config.getIrcdIngameSuffix()
 												+ "!"
@@ -53,192 +87,44 @@ public class IRCReplyCommand implements CommandExecutor {
 												+ IRCd.convertColors(
 														IRCd.join(args, " ", 0),
 														false));
-								player.sendMessage(IRCd.msgSendQueryFromIngame
-										.replace(
-												"{Prefix}",
-												IRCd.getGroupPrefix(ircuser
-														.getTextModes()))
-										.replace(
-												"{Suffix}",
-												IRCd.getGroupSuffix(ircuser
-														.getTextModes()))
-										.replace("{User}", ircuser.nick)
-										.replace(
-												"{Message}",
-												IRCd.convertColors(
-														IRCd.join(args, " ", 0),
-														false)));
-							} else if (IRCd.mode == Modes.INSPIRCD) {
-								BukkitPlayer bp;
-								if ((bp = IRCd.getBukkitUserObject(player
-										.getName())) != null) {
-									String UID = IRCd
-											.getUIDFromIRCUser(ircuser);
-									if (UID != null) {
-										if (IRCd.isLinkcompleted()) {
-											IRCd.privmsg(bp.getUID(), UID, IRCd.convertColors(
-															IRCd.join(args,
-																	" ", 0),
-															false));
-
-											player.sendMessage(IRCd.msgSendQueryFromIngame
-													.replace(
-															"{Prefix}",
-															IRCd.getGroupPrefix(ircuser
-																	.getTextModes()))
-													.replace(
-															"{Suffix}",
-															IRCd.getGroupSuffix(ircuser
-																	.getTextModes()))
-													.replace("{User}",
-															ircuser.nick)
-													.replace(
-															"{Message}",
-															IRCd.convertColors(
-																	IRCd.join(
-																			args,
-																			" ",
-																			0),
-																	false)));
-											;
-										} else
-											player.sendMessage(ChatColor.RED
-													+ "Failed to send message, not currently linked to IRC server.");
-									} else {
-										BukkitIRCdPlugin.log
-												.severe("UID not found in list: "
-														+ UID); // Log this as
-																// severe since
-																// it should
-																// never occur
-																// unless
-																// something is
-																// wrong with
-																// the code
-										player.sendMessage(ChatColor.RED
-												+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-									}
-								} else
-									player.sendMessage(ChatColor.RED
-											+ "Failed to send message, you could not be found in the UID list. This should not happen, please report it to Jdbye.");
-							}
-						} else {
-							player.sendMessage(ChatColor.RED
-									+ "That user is not online.");
-						}
-					}
-				} else {
-					player.sendMessage(ChatColor.RED
-							+ "Please provide a nickname and a message.");
-					return false;
-				}
-			} else {
-				player.sendMessage(ChatColor.RED
-						+ "You don't have access to that command.");
 			}
-			return true;
-		} else {
-			if (args.length > 0) {
-				String lastReceivedFrom = thePlugin.lastReceived
-						.get("@CONSOLE@");
-				if (lastReceivedFrom == null) {
-					sender.sendMessage(ChatColor.RED
-							+ "There are no messages to reply to!");
-				} else {
-					IRCUser ircuser = IRCd.getIRCUser(lastReceivedFrom);
-					if (ircuser != null) {
-						if (IRCd.mode == Modes.STANDALONE) {
-							IRCd.writeTo(
-									ircuser.nick,
-									":"
-											+ Config.getIrcdServerName()
-											+ "!"
-											+ Config.getIrcdServerName()
-											+ "@"
-											+ Config.getIrcdServerHostName()
-											+ " PRIVMSG "
-											+ ircuser.nick
-											+ " :"
-											+ IRCd.convertColors(
-													IRCd.join(args, " ", 0),
-													false));
-							sender.sendMessage(IRCd.msgSendQueryFromIngame
-									.replace(
-											"{Prefix}",
-											IRCd.getGroupPrefix(ircuser
-													.getTextModes()))
-									.replace(
-											"{Suffix}",
-											IRCd.getGroupSuffix(ircuser
-													.getTextModes()))
-									.replace("{User}", ircuser.nick)
-									.replace(
-											"{Message}",
-											IRCd.convertColors(
-													IRCd.join(args, " ", 0),
-													false)));
-							;
-						} else if (IRCd.mode == Modes.INSPIRCD) {
-							String UID = IRCd.getUIDFromIRCUser(ircuser);
-							if (UID != null) {
-								if (IRCd.isLinkcompleted()) {
-									IRCd.privmsg(IRCd.serverUID, UID, IRCd.convertColors(
-											IRCd.join(args, " ", 0),
-											false));
-									sender.sendMessage(IRCd.msgSendQueryFromIngame
-											.replace(
-													"{Prefix}",
-													IRCd.getGroupPrefix(ircuser
-															.getTextModes()))
-											.replace(
-													"{Suffix}",
-													IRCd.getGroupSuffix(ircuser
-															.getTextModes()))
-											.replace("{User}", ircuser.nick)
-											.replace(
-													"{Message}",
-													IRCd.convertColors(
-															IRCd.join(args,
-																	" ", 0),
-															false)));
-									;
-								} else
-									sender.sendMessage(ChatColor.RED
-											+ "Failed to send message, not currently linked to IRC server.");
-							} else {
-								BukkitIRCdPlugin.log
-										.severe("UID not found in list: " + UID); // Log
-																					// this
-																					// as
-																					// severe
-																					// since
-																					// it
-																					// should
-																					// never
-																					// occur
-																					// unless
-																					// something
-																					// is
-																					// wrong
-																					// with
-																					// the
-																					// code
-								sender.sendMessage(ChatColor.RED
-										+ "Failed to send message, UID not found. This should not happen, please report it to Jdbye.");
-							}
-						}
-					} else {
-						sender.sendMessage(ChatColor.RED
-								+ "That user is not online.");
-					}
-				}
-			} else {
+			break;
+		case INSPIRCD:
+			if (!IRCd.isLinkcompleted()) {
 				sender.sendMessage(ChatColor.RED
-						+ "Please provide a nickname and a message.");
-				return false;
+						+ "Failed to send message, not currently linked to IRC server.");
+				return true;
 			}
-			return true;
+
+			final String UID = IRCd.getUIDFromIRCUser(ircuser);
+			if (UID == null) {
+				sender.sendMessage(ChatColor.RED + "Failed to reply, UID not found");
+				return true;
+			}
+
+			if (player == null) {
+				IRCd.privmsg(IRCd.serverUID, UID, IRCd.convertColors(IRCd.join(args, " ", 0),false));
+			} else {
+				final BukkitPlayer bp = IRCd.getBukkitUserObject(player.getName());
+				if (bp == null) {
+					sender.sendMessage(ChatColor.RED + "Internal error, unable to reply");
+					return true;
+				}
+
+				IRCd.privmsg(bp.getUID(), UID, IRCd.convertColors(IRCd.join(args, " ", 0), false));
+			}
+
+			break;
 		}
+
+		// Report command to sender's chat
+		sender.sendMessage(IRCd.msgSendQueryFromIngame
+			.replace("{Prefix}", IRCd.getGroupPrefix(ircuser.getTextModes()))
+			.replace("{Suffix}", IRCd.getGroupSuffix(ircuser.getTextModes()))
+			.replace("{User}", ircuser.nick)
+			.replace("{Message}", IRCd.convertColors(IRCd.join(args, " ", 0), false)));
+
+		return true;
 	}
 
 }

--- a/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/IRCReplyCommand.java
@@ -76,15 +76,11 @@ public class IRCReplyCommand implements CommandExecutor {
 											.getUIDFromIRCUser(ircuser);
 									if (UID != null) {
 										if (IRCd.isLinkcompleted()) {
-											IRCd.println(":"
-													+ bp.getUID()
-													+ " PRIVMSG "
-													+ UID
-													+ " :"
-													+ IRCd.convertColors(
+											IRCd.privmsg(bp.getUID(), UID, IRCd.convertColors(
 															IRCd.join(args,
 																	" ", 0),
 															false));
+
 											player.sendMessage(IRCd.msgSendQueryFromIngame
 													.replace(
 															"{Prefix}",
@@ -186,14 +182,9 @@ public class IRCReplyCommand implements CommandExecutor {
 							String UID = IRCd.getUIDFromIRCUser(ircuser);
 							if (UID != null) {
 								if (IRCd.isLinkcompleted()) {
-									IRCd.println(":"
-											+ IRCd.serverUID
-											+ " PRIVMSG "
-											+ UID
-											+ " :"
-											+ IRCd.convertColors(
-													IRCd.join(args, " ", 0),
-													false));
+									IRCd.privmsg(IRCd.serverUID, UID, IRCd.convertColors(
+											IRCd.join(args, " ", 0),
+											false));
 									sender.sendMessage(IRCd.msgSendQueryFromIngame
 											.replace(
 													"{Prefix}",

--- a/src/com/Jdbye/BukkitIRCd/commands/RawsendCommand.java
+++ b/src/com/Jdbye/BukkitIRCd/commands/RawsendCommand.java
@@ -1,8 +1,6 @@
 package com.Jdbye.BukkitIRCd.commands;
 
-import com.Jdbye.BukkitIRCd.BukkitIRCdPlugin;
 import com.Jdbye.BukkitIRCd.IRCd;
-import com.Jdbye.BukkitIRCd.Modes;
 import com.Jdbye.BukkitIRCd.configuration.Config;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -12,34 +10,39 @@ import org.bukkit.entity.Player;
 
 public class RawsendCommand implements CommandExecutor{
 
-	@SuppressWarnings("unused")
-	private BukkitIRCdPlugin thePlugin;
-
-	public RawsendCommand(BukkitIRCdPlugin plugin) {
-		this.thePlugin = plugin;
-	}
+	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label,
 			String[] args) {
+
 		if (sender instanceof Player){
 			if (Config.isEnableRawSend()) {
 				sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Only the console can use this command.");
+			} else {
+				sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Sending raw messages is disabled. Please enable them in the config first.");
 			}
-			else { sender.sendMessage(ChatColor.RED + "[BukkitIRCd] Sending raw messages is disabled. Please enable them in the config first."); }
-			return true;
-		
-		}else{
+		} else {
 			if (Config.isEnableRawSend()) {
 				if (args.length > 0) {
-					if ((IRCd.mode == Modes.INSPIRCD) || (IRCd.mode == Modes.UNREALIRCD)) {
-						if (IRCd.println(IRCd.join(args, " ", 0))) sender.sendMessage(ChatColor.RED + "Command sent to IRC server link.");
-						else sender.sendMessage(ChatColor.RED + "Failed to send command to IRC server link, not currently linked.");
-					}
-				}
-				else { sender.sendMessage(ChatColor.RED + "Please provide a command to send."); return false; }
-			}
-			else { sender.sendMessage(ChatColor.RED + "Rawsend is not enabled."); }
-			return true;
-		}
-	}
+					switch (IRCd.mode) {
+					case INSPIRCD:
+						if (IRCd.println(IRCd.join(args, " ", 0))) {
+							sender.sendMessage(ChatColor.RED + "Command sent to IRC server link.");
+						} else {
+							sender.sendMessage(ChatColor.RED + "Failed to send command to IRC server link, not currently linked.");
+						}
+						break;
 
+					case STANDALONE:
+						sender.sendMessage(ChatColor.RED + "Please provide a command to send.");
+						break;
+					}
+				} else {
+					return false;
+				}
+			} else {
+					sender.sendMessage(ChatColor.RED + "Rawsend is not enabled.");
+			}
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
These clean ups include removal of incomplete UNREALIRCD support, the creation of privmsg and action methods, and a rewrite/cleanup of the IRCReply command (more rewrites to follow). The rewrites are focused around cleaning up the control flow and isolating the differences between standalone and inspircd modes to make those easier to split eventually
