### PR TITLE
Allow disconnect without reason.

### DIFF
--- a/src/com/Jdbye/BukkitIRCd/IRCd.java
+++ b/src/com/Jdbye/BukkitIRCd/IRCd.java
@@ -2967,14 +2967,12 @@ public class IRCd implements Runnable {
 	}
 
 	public static void disconnectServer(String reason) {
-		if (reason == null)
-			reason = "Disabling Plugin";
 		synchronized (csServer) {
 			if (mode == Modes.INSPIRCD) {
 				if ((server != null) && server.isConnected()) {
 					println(pre + "SQUIT " + Config.getLinkServerID() + " :" + reason);
 					if (linkcompleted) {
-						if (msgDelinkedReason.length() > 0)
+						if (reason != null && msgDelinkedReason.length() > 0)
 							IRCd.broadcastMessage(
 											msgDelinkedReason
 													.replace("{LinkName}",


### PR DESCRIPTION
In certain cases like onDisable, it isn't possible to broadcast.
because broadcasts inside the IRCd are implemented by scheduling
a synchronous task and you can't schedule a task on a disabled
plugin.
